### PR TITLE
Hide channelErrorLabel when streaming is possible on channel

### DIFF
--- a/Odysee/Controllers/Library/GoLiveViewController.swift
+++ b/Odysee/Controllers/Library/GoLiveViewController.swift
@@ -250,7 +250,8 @@ class GoLiveViewController: UIViewController, UIPickerViewDataSource, UIPickerVi
         .subscribeResult(didLoadChannels)
     }
 
-    func canStreamOnChannel(_ channel: Claim?) -> Bool {
+    /// Checks if it's possible to stream on `channel`, and update the error label with the reason if not.
+    func checkCanStreamOnChannel(_ channel: Claim?) -> Bool {
         if channel == nil {
             return false
         }
@@ -329,7 +330,7 @@ class GoLiveViewController: UIViewController, UIPickerViewDataSource, UIPickerVi
             // check the selected picker item
             if self.channels.count > 0 {
                 self.selectedChannel = self.channels[self.channelPicker.selectedRow(inComponent: 0)]
-                _ = self.canStreamOnChannel(self.selectedChannel)
+                _ = self.checkCanStreamOnChannel(self.selectedChannel)
             }
         }
     }
@@ -342,7 +343,7 @@ class GoLiveViewController: UIViewController, UIPickerViewDataSource, UIPickerVi
             return
         }
 
-        if !canStreamOnChannel(selectedChannel) {
+        if !checkCanStreamOnChannel(selectedChannel) {
             showError(message: String.localized("Please select a valid channel to continue"))
             return
         }
@@ -504,7 +505,7 @@ class GoLiveViewController: UIViewController, UIPickerViewDataSource, UIPickerVi
 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         selectedChannel = channels[row]
-        _ = canStreamOnChannel(selectedChannel)
+        _ = checkCanStreamOnChannel(selectedChannel)
     }
 
     @IBAction func selectImageTapped(_ sender: UIButton) {

--- a/Odysee/Controllers/Library/GoLiveViewController.swift
+++ b/Odysee/Controllers/Library/GoLiveViewController.swift
@@ -255,29 +255,33 @@ class GoLiveViewController: UIViewController, UIPickerViewDataSource, UIPickerVi
             return false
         }
 
-        var effectiveAmount = Decimal(0)
         let channel = channels[0]
         if channel.confirmations! < 1 {
+            channelErrorLabel.isHidden = false
             channelErrorLabel.text = String
                 .localized("Your channel is still pending. Please wait a couple of minutes and try again.")
             return false
         }
 
-        if let meta = channel.meta {
-            effectiveAmount = Decimal(string: meta.effectiveAmount!)!
-        }
-        if effectiveAmount < GoLiveViewController.minStreamStake {
-            channelErrorLabel.text = String(
-                format: String
-                    .localized(
-                        "You need to have at least %@ credits staked (directly or through supports) on %@ to be able to livestream."
-                    ),
-                String(describing: GoLiveViewController.minStreamStake),
-                channel.name!
-            )
-            return false
-        }
-
+        // Disabled due to lack of server side checking for now
+//        var effectiveAmount = Decimal(0)
+//        if let meta = channel.meta {
+//            effectiveAmount = Decimal(string: meta.effectiveAmount!)!
+//        }
+//        if effectiveAmount < GoLiveViewController.minStreamStake {
+//            channelErrorLabel.isHidden = false
+//            channelErrorLabel.text = String(
+//                format: String
+//                    .localized(
+//                        "You need to have at least %@ credits staked (directly or through supports) on %@ to be able to livestream."
+//                    ),
+//                String(describing: GoLiveViewController.minStreamStake),
+//                channel.name!
+//            )
+//            return false
+//        }
+        
+        channelErrorLabel.isHidden = true
         return true
     }
 


### PR DESCRIPTION
Also rename `canStreamOnChannel` to `checkCanStreamOnChannel`. It makes more sense since it sets the `channelErrorLabel` text as well as returning the status.

Alternatively it could be renamed to `checkCanStreamOnChannelAndSetLabelText`, but that's very verbose.