### PR TITLE
Don't show channel view when long pressing placeholder

### DIFF
--- a/Odysee/Controllers/Channel/ChannelManagerViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelManagerViewController.swift
@@ -167,11 +167,13 @@ class ChannelManagerViewController: UIViewController, UITableViewDelegate, UITab
             let touchPoint = longPressGestureRecognizer.location(in: channelListView)
             if let indexPath = channelListView.indexPathForRow(at: touchPoint) {
                 let claim: Claim = channels[indexPath.row]
-                let appDelegate = UIApplication.shared.delegate as! AppDelegate
-                let vc = appDelegate.mainController.storyboard?
-                    .instantiateViewController(identifier: "channel_view_vc") as! ChannelViewController
-                vc.channelClaim = claim
-                appDelegate.mainNavigationController?.pushViewController(vc, animated: true)
+                if claim.claimId != "new" {
+                    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+                    let vc = appDelegate.mainController.storyboard?
+                        .instantiateViewController(identifier: "channel_view_vc") as! ChannelViewController
+                    vc.channelClaim = claim
+                    appDelegate.mainNavigationController?.pushViewController(vc, animated: true)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes a crash due to attempting to get following status on placeholder
channel.