### PR TITLE
Handle odysee.com links, Use LbryUri isChannelUrl which has correct logic

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -327,9 +327,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 return
             }
 
-            let lbryUrl = LbryUri.tryParse(url: finalTarget, requireProto: false)
-            if lbryUrl != nil {
-                if lbryUrl!.isChannelUrl() {
+            if let lbryUrl = LbryUri.tryParse(url: finalTarget, requireProto: false) {
+                if lbryUrl.isChannel {
                     let vc = mainViewController?.storyboard?
                         .instantiateViewController(identifier: "channel_view_vc") as! ChannelViewController
                     vc.claimUrl = lbryUrl

--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -58,9 +58,8 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
                 return
             }
 
-            let lbryUrl = LbryUri.tryParse(url: appDelegate.pendingOpenUrl!, requireProto: false)
-            if lbryUrl != nil {
-                if lbryUrl!.isChannelUrl() {
+            if let lbryUrl = LbryUri.tryParse(url: appDelegate.pendingOpenUrl!, requireProto: false) {
+                if lbryUrl.isChannel {
                     let vc = storyboard?
                         .instantiateViewController(identifier: "channel_view_vc") as! ChannelViewController
                     vc.claimUrl = lbryUrl

--- a/Odysee/Controllers/User/NotificationsViewController.swift
+++ b/Odysee/Controllers/User/NotificationsViewController.swift
@@ -283,9 +283,8 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
                 return
             }
 
-            let lbryUrl = LbryUri.tryParse(url: notification.targetUrl!, requireProto: false)
-            if lbryUrl != nil {
-                if lbryUrl!.isChannelUrl() {
+            if let lbryUrl = LbryUri.tryParse(url: notification.targetUrl!, requireProto: false) {
+                if lbryUrl.isChannel {
                     let vc = storyboard?
                         .instantiateViewController(identifier: "channel_view_vc") as! ChannelViewController
                     vc.claimUrl = lbryUrl

--- a/Odysee/Odysee.entitlements
+++ b/Odysee/Odysee.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:odysee.com</string>
+	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
 </dict>

--- a/Odysee/SceneDelegate.swift
+++ b/Odysee/SceneDelegate.swift
@@ -86,9 +86,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 return
             }
 
-            let lbryUrl = LbryUri.tryParse(url: url.absoluteString, requireProto: false)
-            if lbryUrl != nil {
-                if lbryUrl!.isChannelUrl() {
+            if let lbryUrl = LbryUri.tryParse(url: url.absoluteString, requireProto: false) {
+                if lbryUrl.isChannel {
                     let vc = appDelegate.mainViewController?.storyboard?
                         .instantiateViewController(identifier: "channel_view_vc") as! ChannelViewController
                     vc.claimUrl = lbryUrl

--- a/Odysee/SceneDelegate.swift
+++ b/Odysee/SceneDelegate.swift
@@ -30,6 +30,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else { return }
+        handleLaunchUrl(url: url)
+    }
+
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let url = URLContexts.first?.url else { return }
         handleLaunchUrl(url: url)

--- a/Odysee/Utils/LbryUri.swift
+++ b/Odysee/Utils/LbryUri.swift
@@ -73,10 +73,6 @@ struct LbryUri: CustomStringConvertible {
         return build(includeProto: true, protoDefault: LbryUri.protoDefault, vanity: true)
     }
 
-    func isChannelUrl() -> Bool {
-        return (!(channelName ?? "").isBlank && (streamName ?? "").isBlank) || (claimName ?? "").starts(with: "@")
-    }
-
     static func isNameValid(_ name: String?) -> Bool {
         return !(name ?? "").isBlank && regexInvalidUri
             .firstMatch(in: name!, options: [], range: NSRange(name!.startIndex..., in: name!)) == nil


### PR DESCRIPTION
## Changes made

### Use isChannel property from LbryUri to determine if is channel

The logic in isChannelUrl() is broken (due to boolean or-ing if it
starts with @, which also applies to URLs that start with a channel), so
remove it and just use the isChannel property which _is_ set correctly.

### Handle odysee.com links