### PR TITLE
Reposted claims improvements

### DIFF
--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -388,7 +388,7 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
         Lbry.apiCall(
             method: Lbry.Methods.claimSearch,
             params: .init(
-                claimType: [.stream],
+                claimType: [.stream, .repost],
                 page: currentPage,
                 pageSize: pageSize,
                 releaseTime: releaseTimeValue,


### PR DESCRIPTION
## Changes made

### Don't attempt to show reposted claim if it's a channel

In FileViewController, the code was attempting to display the claim after resolving it, even if it was found to be a channel, because code was running before the view controller got popped and the channel controller was shown.

Fix: #218 

### Add overlay with repost channel on reposted claims

Similar to on odysee.com, add a slightly transparent diagonal overlay with the reposter channel.

### Show claims reposted by channel in channel view