### PR TITLE
Clear lazyPlayer when opening offline livestream

### DIFF
--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -558,6 +558,9 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
 
     func displayLivestreamOffline() {
         DispatchQueue.main.async {
+            let appDelegate = UIApplication.shared.delegate as! AppDelegate
+            appDelegate.lazyPlayer = nil
+
             self.avpc.view.isHidden = true
             self.livestreamOfflinePlaceholder.isHidden = false
             self.livestreamOfflineMessageView.isHidden = false


### PR DESCRIPTION
Make mini player hide when closing file view after opening offline
livestream.

Fix: #298