### PR TITLE
Search: Add Sort By picker, Use Lighthouse query params

### DIFF
--- a/Odysee/Base.lproj/Main.storyboard
+++ b/Odysee/Base.lproj/Main.storyboard
@@ -7449,6 +7449,28 @@
                                                 </subviews>
                                                 <edgeInsets key="layoutMargins" top="16" left="16" bottom="0.0" right="16"/>
                                             </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6z1-dn-gV1" userLabel="Sort By Area">
+                                                <rect key="frame" x="0.0" y="232" width="414" height="116"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sort By" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RHn-3t-8gg">
+                                                        <rect key="frame" x="16" y="16" width="382" height="0.0"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C1g-oX-Dsw" userLabel="Sort By Picker View">
+                                                        <rect key="frame" x="16" y="16" width="382" height="100"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="100" id="zwS-f1-fZA"/>
+                                                        </constraints>
+                                                        <connections>
+                                                            <outlet property="dataSource" destination="ZK9-XQ-4P5" id="MvS-FH-YLY"/>
+                                                            <outlet property="delegate" destination="ZK9-XQ-4P5" id="5Tj-rC-shA"/>
+                                                        </connections>
+                                                    </pickerView>
+                                                </subviews>
+                                                <edgeInsets key="layoutMargins" top="16" left="16" bottom="0.0" right="16"/>
+                                            </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemGray6Color"/>
                                     </stackView>
@@ -7564,7 +7586,8 @@
                         <outlet property="publishTimePicker" destination="fju-rI-QGR" id="DcQ-Ek-hrS"/>
                         <outlet property="resultsListView" destination="vI9-g9-FJ7" id="0iO-uC-lbY"/>
                         <outlet property="searchBar" destination="CLn-VR-8NN" id="Lrn-Xo-vbL"/>
-                        <outlet property="typePickerView" destination="wqY-Dx-yu0" id="Giz-SF-MuM"/>
+                        <outlet property="sortByPicker" destination="C1g-oX-Dsw" id="kKL-bS-AVx"/>
+                        <outlet property="typePicker" destination="wqY-Dx-yu0" id="2CS-25-k2w"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cgx-PA-j5N" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Odysee/Models/Claim.swift
+++ b/Odysee/Models/Claim.swift
@@ -23,13 +23,6 @@ enum StreamType: String, Codable {
     case video
 }
 
-enum MediaType: String {
-    case video
-    case audio
-    case image
-    case text
-}
-
 class Claim: Decodable, Equatable, Hashable {
     var address: String?
     var amount: String?

--- a/Odysee/Utils/Extensions.swift
+++ b/Odysee/Utils/Extensions.swift
@@ -222,3 +222,32 @@ extension Publisher {
         )
     }
 }
+
+extension Collection {
+    /// Modified implementation of sorted(like:keyPath:) from SwifterSwift that applies a transform
+    ///
+    /// SwifterSwift: Sort an array like another array based on a key path. If the other array doesn't contain a certain value, it will be sorted last. If transform throws the element will be sorted last.
+    ///
+    ///        [MyStruct(x: 4), MyStruct(x: 2), MyStruct(x: 3)].sorted(like: [1, 2, 3], keyPath: \.x, transform: { $0 - 1 })
+    ///            -> [MyStruct(x: 1), MyStruct(x: 2), MyStruct(x: 3)]
+    ///
+    /// - Parameters:
+    ///   - otherArray: array containing elements in the desired order.
+    ///   - keyPath: keyPath indicating the property that the array should be sorted by
+    ///   - transform: function applying a transform on the keyPath property before sorting.
+    /// - Returns: sorted array.
+    func sorted<T: Hashable>(
+        like otherArray: [T],
+        keyPath: KeyPath<Element, T>,
+        transform: (T) throws -> T
+    ) -> [Element] {
+        let dict = otherArray.enumerated().reduce(into: [:]) { $0[$1.element] = $1.offset }
+        return sorted {
+            guard let thisElem = try? transform($0[keyPath: keyPath]) else { return false }
+            guard let otherElem = try? transform($1[keyPath: keyPath]) else { return true }
+            guard let thisIndex = dict[thisElem] else { return false }
+            guard let otherIndex = dict[otherElem] else { return true }
+            return thisIndex < otherIndex
+        }
+    }
+}

--- a/Odysee/Utils/Lighthouse.swift
+++ b/Odysee/Utils/Lighthouse.swift
@@ -44,6 +44,9 @@ final class Lighthouse {
         size: Int,
         from: Int,
         relatedTo: String?,
+        claimType: ClaimType? = nil,
+        mediaTypes: [MediaType]? = nil,
+        sortBy: SortBy? = nil,
         completion: @escaping ([[String: Any]]?, Error?) -> Void
     ) {
         if !(relatedTo ?? "").isBlank {
@@ -77,6 +80,19 @@ final class Lighthouse {
         queryItems.append(URLQueryItem(name: "filters", value: "ios"))
         if !(relatedTo ?? "").isBlank {
             queryItems.append(URLQueryItem(name: "related_to", value: String(relatedTo!)))
+        }
+        if let claimType = claimType {
+            queryItems.append(URLQueryItem(name: "claimType", value: claimType.rawValue))
+
+            if claimType == .stream {
+                queryItems.append(URLQueryItem(
+                    name: "mediaType",
+                    value: mediaTypes?.map(\.rawValue).joined(separator: ",")
+                ))
+            }
+        }
+        if let sortBy = sortBy {
+            queryItems.append(URLQueryItem(name: "sort_by", value: sortBy.rawValue))
         }
 
         var urlComponents = URLComponents(string: String(format: "%@/search", connectionString))
@@ -112,5 +128,17 @@ final class Lighthouse {
             }
         })
         task.resume()
+    }
+
+    enum MediaType: String {
+        case video
+        case audio
+        case image
+        case text
+    }
+
+    enum SortBy: String {
+        case ascending = "^release_time"
+        case descending = "release_time"
     }
 }


### PR DESCRIPTION
Use Lighthouse query params instead of filterClaims() for claim/media
type filtering and sorting.

Use sorted(like:keyPath:transform:) method to make the claims shown
match the order returned by Lighthouse, as they get reordered when
resolving a batch of URLs.

Fix: #199
Fix: #308