### PR TITLE
Use URL object in share sheet item

### DIFF
--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -677,8 +677,8 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
 
     @IBAction func shareActionTapped(_ sender: Any) {
         let url = LbryUri.tryParse(url: channelClaim!.shortUrl!, requireProto: false)
-        if url != nil {
-            let items = [url!.odyseeString]
+        if let url = url {
+            let items: [Any] = [URL(string: url.odyseeString) ?? url.odyseeString]
             let vc = UIActivityViewController(activityItems: items, applicationActivities: nil)
             vc.popoverPresentationController?.sourceView = shareView
             present(vc, animated: true)

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -1946,8 +1946,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     @IBAction func shareActionTapped(_ sender: Any) {
         let shareClaim = isPlaylist ? currentPlaylistClaim() : claim!
         let url = LbryUri.tryParse(url: shareClaim.canonicalUrl!, requireProto: false)
-        if url != nil {
-            let items = [url!.odyseeString]
+        if let url = url {
+            let items: [Any] = [URL(string: url.odyseeString) ?? url.odyseeString]
             let vc = UIActivityViewController(activityItems: items, applicationActivities: nil)
             vc.popoverPresentationController?.sourceView = shareActionView
             present(vc, animated: true)


### PR DESCRIPTION
Allows using URL-specific share sheet actions.

Fix: #325