### PR TITLE
Fix loading view always showing when scrolling home page

### DIFF
--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -361,8 +361,8 @@ class HomeViewController: UIViewController,
             return
         }
 
-        if livestreamsCollectionView.contentOffset
-            .x >= (livestreamsCollectionView.contentSize.width - livestreamsCollectionView.bounds.size.width)
+        if scrollView == livestreamsCollectionView && livestreamsCollectionView.contentOffset.x >=
+            (livestreamsCollectionView.contentSize.width - livestreamsCollectionView.bounds.size.width)
         {
             if !loadingLivestreams, !livestreamsLastPageReached {
                 livestreamsCurrentPage += 1


### PR DESCRIPTION
Livestreams view is considered to have reached end when no livestreams
to display.

To fix, check if livestreams view was scrolled instead of just if it
reached end.