### PR TITLE
Do not close when tapping on empty space in User Account Menu

### DIFF
--- a/Odysee/Base.lproj/Main.storyboard
+++ b/Odysee/Base.lproj/Main.storyboard
@@ -3545,6 +3545,7 @@
                 <tapGestureRecognizer id="9iR-Vf-FY5" userLabel="Anywhere Tap Gesture Recognizer">
                     <connections>
                         <action selector="anywhereTapped:" destination="Lba-J3-7h3" id="249-lS-D7Q"/>
+                        <outlet property="delegate" destination="Lba-J3-7h3" id="krV-9C-Ugo"/>
                     </connections>
                 </tapGestureRecognizer>
                 <tapGestureRecognizer id="8NM-bn-GSW" userLabel="Channels Tap Gesture Recognizer">

--- a/Odysee/Controllers/User/UserAccountMenuViewController.swift
+++ b/Odysee/Controllers/User/UserAccountMenuViewController.swift
@@ -8,7 +8,7 @@
 import SafariServices
 import UIKit
 
-class UserAccountMenuViewController: UIViewController {
+class UserAccountMenuViewController: UIViewController, UIGestureRecognizerDelegate {
     @IBOutlet var contentView: UIView!
     @IBOutlet var signUpLoginButton: UIButton!
     @IBOutlet var loggedInMenu: UIView!
@@ -40,6 +40,10 @@ class UserAccountMenuViewController: UIViewController {
         if Lbryio.isSignedIn() {
             userEmailLabel.text = Lbryio.currentUser?.primaryEmail!
         }
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return touch.view == gestureRecognizer.view
     }
 
     @IBAction func anywhereTapped(_ sender: Any) {


### PR DESCRIPTION
Previously tapping on empty space within the menu would close it.
Now only tapping outside the menu closes it.