### PR TITLE
Comments crash and misc fixes

### DIFF
--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -2321,9 +2321,12 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                 showError(message: String.localized("Please wait while we load your channels"))
                 return false
             }
-            if currentCommentAsIndex == -1 || channels.count == 0 {
-                showError(message: String.localized("You need to select a channel to post your comment as"))
+            if channels.count == 0 {
+                showError(message: String.localized("You need to create a channel before you can post comments"))
                 return false
+            }
+            if currentCommentAsIndex == -1 {
+                showError(message: String.localized("No channel selected. This is probably a bug."))
             }
 
             let commentAsChannel = channels[currentCommentAsIndex]

--- a/Odysee/Models/CommentAPIParams.swift
+++ b/Odysee/Models/CommentAPIParams.swift
@@ -42,6 +42,6 @@ struct CommentReactListParams: Encodable {
     var commentIds: String
     var channelName: String?
     var channelId: String?
-    var signature: String
-    var signingTs: String
+    var signature: String?
+    var signingTs: String?
 }


### PR DESCRIPTION
- Fix crash getting channel to load reactions with when signed out.
- Add additional checks for no selected or loaded channels.
- Fix comments not showing due to wrongly filtering blocked channels.

Fix: #369