### PR TITLE
Don't autoplay if already playing, persistent miniplayer

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -92,7 +92,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 if let currentFileViewController = currentFileViewController {
                     currentFileViewController.checkTimeToStart()
                     DispatchQueue.main.async {
-                        currentFileViewController.avpc.player?.rate = currentFileViewController.playerRate
+                        self.lazyPlayer?.rate = currentFileViewController.playerRate
                     }
                 }
                 return
@@ -272,6 +272,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = currentItem.asset.duration.seconds
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = lazyPlayer.rate
         nowPlayingInfoCenter.nowPlayingInfo = nowPlayingInfo
+
+        (mainViewController as? MainViewController)?.miniPlayerPlayPauseButton.image = UIImage(
+            systemName: lazyPlayer.rate == 0 ? "play.fill" : "pause.fill"
+        )
     }
 
     private func makeMediaItem(_ image: UIImage) -> MPMediaItemArtwork {

--- a/Odysee/Base.lproj/Main.storyboard
+++ b/Odysee/Base.lproj/Main.storyboard
@@ -232,6 +232,17 @@
                                         </subviews>
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
+                                    <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pause.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="SYE-EE-h4a" userLabel="Play Pause Button">
+                                        <rect key="frame" x="346" y="2" width="24" height="86"/>
+                                        <color key="tintColor" systemColor="labelColor"/>
+                                        <gestureRecognizers/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="h65-yR-jXm"/>
+                                        </constraints>
+                                        <connections>
+                                            <outletCollection property="gestureRecognizers" destination="9ns-eW-JdI" appends="YES" id="o8q-gJ-xxx"/>
+                                        </connections>
+                                    </imageView>
                                     <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sharp_close_black_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="5Fw-oG-SwQ">
                                         <rect key="frame" x="386" y="0.0" width="24" height="90"/>
                                         <color key="tintColor" systemColor="labelColor"/>
@@ -247,15 +258,18 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <gestureRecognizers/>
                                 <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="SYE-EE-h4a" secondAttribute="bottom" id="7tn-cA-Tv4"/>
+                                    <constraint firstItem="SYE-EE-h4a" firstAttribute="top" secondItem="MkF-lQ-MQ4" secondAttribute="top" id="B7r-uP-vMw"/>
                                     <constraint firstItem="GdG-4w-vOQ" firstAttribute="leading" secondItem="MkF-lQ-MQ4" secondAttribute="leading" id="L01-p7-mFC"/>
-                                    <constraint firstItem="5Fw-oG-SwQ" firstAttribute="leading" secondItem="ZMe-Cs-ZmQ" secondAttribute="trailing" id="Q8j-qB-1Xf"/>
                                     <constraint firstItem="5Fw-oG-SwQ" firstAttribute="top" secondItem="MkF-lQ-MQ4" secondAttribute="top" id="VQY-eH-aCQ"/>
+                                    <constraint firstItem="SYE-EE-h4a" firstAttribute="trailing" secondItem="5Fw-oG-SwQ" secondAttribute="leading" constant="-16" id="Wb1-l6-gZb"/>
                                     <constraint firstItem="ZMe-Cs-ZmQ" firstAttribute="centerY" secondItem="MkF-lQ-MQ4" secondAttribute="centerY" id="dZs-Hm-V6u"/>
                                     <constraint firstAttribute="bottom" secondItem="GdG-4w-vOQ" secondAttribute="bottom" id="eXu-md-1QR"/>
                                     <constraint firstItem="GdG-4w-vOQ" firstAttribute="top" secondItem="MkF-lQ-MQ4" secondAttribute="top" id="hVg-K4-WGd"/>
                                     <constraint firstAttribute="trailing" secondItem="5Fw-oG-SwQ" secondAttribute="trailing" id="j1a-bI-CxK"/>
                                     <constraint firstAttribute="bottom" secondItem="5Fw-oG-SwQ" secondAttribute="bottom" id="mbT-qa-o1P"/>
                                     <constraint firstAttribute="height" constant="90" id="o7P-AO-yZU"/>
+                                    <constraint firstItem="ZMe-Cs-ZmQ" firstAttribute="trailing" secondItem="SYE-EE-h4a" secondAttribute="leading" id="rti-06-ZrV"/>
                                     <constraint firstItem="ZMe-Cs-ZmQ" firstAttribute="leading" secondItem="GdG-4w-vOQ" secondAttribute="trailing" id="sdr-Lg-Kgb"/>
                                 </constraints>
                                 <connections>
@@ -285,6 +299,7 @@
                         <outlet property="mainBalanceLabel" destination="3gz-dN-Qi8" id="X4p-4q-U8U"/>
                         <outlet property="miniPlayerBottomConstraint" destination="92u-Po-iNL" id="Sa5-vu-Bs8"/>
                         <outlet property="miniPlayerMediaView" destination="GdG-4w-vOQ" id="sdg-ta-Af2"/>
+                        <outlet property="miniPlayerPlayPauseButton" destination="SYE-EE-h4a" id="bk7-t2-3oM"/>
                         <outlet property="miniPlayerPublisherLabel" destination="EkP-1M-Aqs" id="2a0-qV-2ay"/>
                         <outlet property="miniPlayerTitleLabel" destination="07y-sU-PS6" id="ZEn-ij-ZF1"/>
                         <outlet property="miniPlayerView" destination="MkF-lQ-MQ4" id="pWH-2z-YS8"/>
@@ -298,6 +313,11 @@
                 <tapGestureRecognizer id="gWy-Py-4d1" userLabel="Close Mini Player Tap Gesture">
                     <connections>
                         <action selector="closeMiniPlayerTapped:" destination="NqH-oh-ggT" id="Tv4-sV-eRR"/>
+                    </connections>
+                </tapGestureRecognizer>
+                <tapGestureRecognizer id="9ns-eW-JdI" userLabel="Play Pause Mini Player Tap Gesture Recognizer">
+                    <connections>
+                        <action selector="playPauseMiniPlayerTapped:" destination="NqH-oh-ggT" id="dbB-Es-2Mz"/>
                     </connections>
                 </tapGestureRecognizer>
                 <tapGestureRecognizer id="aTt-9P-bLh" userLabel="Restore File View Tap Gesture">
@@ -8402,6 +8422,7 @@
         <image name="line.3.horizontal.decrease.circle.fill" catalog="system" width="128" height="121"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
         <image name="odysee_logo" width="307" height="306"/>
+        <image name="pause.fill" catalog="system" width="116" height="128"/>
         <image name="pencil" catalog="system" width="128" height="113"/>
         <image name="person.crop.circle" catalog="system" width="128" height="121"/>
         <image name="play.tv" catalog="system" width="128" height="97"/>

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -118,6 +118,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
 
     let avpc = TouchInterceptingAVPlayerViewController()
     var avpcIsReadyObserver: NSKeyValueObservation?
+    var player: AVPlayer?
+    var playerStartedObserver: NSKeyValueObservation?
     weak var commentsVc: CommentsViewController!
 
     var commentsDisabledChecked = false
@@ -191,7 +193,9 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
 
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.mainController.toggleHeaderVisibility(hidden: true)
-        appDelegate.mainController.toggleMiniPlayer(hidden: true)
+        if appDelegate.currentClaim != nil && appDelegate.currentClaim?.claimId == claim?.claimId {
+            appDelegate.mainController.toggleMiniPlayer(hidden: true)
+        }
         appDelegate.currentFileViewController = self
 
         if claim != nil, !isPlaylist {
@@ -242,7 +246,6 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         super.viewWillDisappear(animated)
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
 
-        appDelegate.currentClaim = isTextContent || isImageContent || isOtherContent ? nil : claim
         appDelegate.mainController.updateMiniPlayer()
 
         if appDelegate.lazyPlayer != nil {
@@ -1009,30 +1012,41 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             return
         }
 
-        appDelegate.currentClaim = singleClaim
-        appDelegate.lazyPlayer?.pause()
-
-        appDelegate.playerObserverAdded = false
-
         let asset = AVURLAsset(url: sourceUrl, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
         let playerItem = AVPlayerItem(asset: asset)
-        appDelegate.lazyPlayer = AVPlayer(playerItem: playerItem)
+        player = AVPlayer(playerItem: playerItem)
+        avpc.player = player
 
-        appDelegate.registerPlayerObserver()
-        avpc.player = appDelegate.lazyPlayer
-        playerConnected = true
-        playRequestTime = Int64(Date().timeIntervalSince1970 * 1000.0)
+        playerStartedObserver = player?.observe(\.rate, options: .new) { [self] _, _ in
+            playerStartedObserver = nil
 
-        avpc.player!.play()
+            (appDelegate.mainViewController as? MainViewController)?.closeMiniPlayerTapped(self)
 
-        if #available(iOS 14.2, *) {
-            avpc.canStartPictureInPictureAutomaticallyFromInline = true
+            appDelegate.currentClaim = singleClaim
+            appDelegate.lazyPlayer?.pause()
+
+            appDelegate.lazyPlayer = player
+            avpc.player = appDelegate.lazyPlayer
+            player = nil
+
+            appDelegate.playerObserverAdded = false
+            appDelegate.registerPlayerObserver()
+            playerConnected = true
+            playRequestTime = Int64(Date().timeIntervalSince1970 * 1000.0)
+
+            if #available(iOS 14.2, *) {
+                avpc.canStartPictureInPictureAutomaticallyFromInline = true
+            }
+            if UserDefaults.standard.integer(forKey: "BackgroundPlaybackMode") != 0 {
+                avpc.allowsPictureInPicturePlayback = false
+            }
+
+            appDelegate.setupRemoteTransportControls()
         }
-        if UserDefaults.standard.integer(forKey: "BackgroundPlaybackMode") != 0 {
-            avpc.allowsPictureInPicturePlayback = false
-        }
 
-        appDelegate.setupRemoteTransportControls()
+        if appDelegate.lazyPlayer == nil {
+            avpc.player?.play()
+        }
     }
 
     func displayRelatedPlaceholders() {

--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -22,6 +22,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
     @IBOutlet var miniPlayerMediaView: UIView!
     @IBOutlet var miniPlayerTitleLabel: UILabel!
     @IBOutlet var miniPlayerPublisherLabel: UILabel!
+    @IBOutlet var miniPlayerPlayPauseButton: UIImageView!
 
     @IBOutlet var mainBalanceLabel: UILabel!
 
@@ -266,6 +267,19 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
         toggleMiniPlayer(hidden: true)
     }
 
+    @IBAction func playPauseMiniPlayerTapped(_ sender: Any) {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        if let lazyPlayer = appDelegate.lazyPlayer {
+            if lazyPlayer.rate == 0 {
+                lazyPlayer.play()
+                miniPlayerPlayPauseButton.image = UIImage(systemName: "pause.fill")
+            } else {
+                lazyPlayer.pause()
+                miniPlayerPlayPauseButton.image = UIImage(systemName: "play.fill")
+            }
+        }
+    }
+
     @IBAction func uploadTapped(_ sender: Any) {
         let currentVc = UIApplication.currentViewController()
         if (currentVc as? PublishViewController) != nil {
@@ -311,6 +325,9 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
 
     @IBAction func openCurrentClaim(_ sender: Any) {
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        if let _ = appDelegate.currentFileViewController {
+            appDelegate.mainNavigationController?.popViewController(animated: false)
+        }
         if appDelegate.currentClaim != nil {
             let vc = storyboard?.instantiateViewController(identifier: "file_view_vc") as! FileViewController
             vc.claim = appDelegate.currentClaim


### PR DESCRIPTION
- Add play/pause button to miniplayer.
- Add player variable to FileViewController, to which
  appDelegate.lazyPlayer is set when playback starts.
  Allows player initialization without overriding miniplayer.
- Only hide miniplayer if opening FileViewController with same claim.

Fix: #240