### PR TITLE
uploads: swap long/short press behaviour

### DIFF
--- a/Odysee/Controllers/Channel/ChannelManagerViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelManagerViewController.swift
@@ -188,12 +188,6 @@ class ChannelManagerViewController: UIViewController, UITableViewDelegate, UITab
                 return
             }
 
-            if claim.confirmations ?? 0 == 0 {
-                // pending claim
-                showError(message: "You cannot remove a pending channel. Please try again later.")
-                return
-            }
-
             // show confirmation dialog before deleting
             let alert = UIAlertController(
                 title: String.localized("Abandon channel?"),

--- a/Odysee/UI/ClaimTableViewCell.swift
+++ b/Odysee/UI/ClaimTableViewCell.swift
@@ -142,9 +142,10 @@ class ClaimTableViewCell: UITableViewCell {
         if releaseTime == 0 {
             releaseTime = Double(actualClaim.timestamp ?? 0)
         }
+        let confirmations = actualClaim.confirmations ?? 0
 
         publishTimeLabel.textColor = actualClaim.featured ? UIColor.white : nil
-        if releaseTime > 0 {
+        if releaseTime > 0 && confirmations > 0 {
             let date = Date(timeIntervalSince1970: releaseTime) // TODO: Timezone check / conversion?
             publishTimeLabel.text = Helper.fullRelativeDateFormatter.localizedString(for: date, relativeTo: Date())
         } else {


### PR DESCRIPTION
Other changes:
- Allow deleting uploads/channels before confirmation
- Fix pending claims not updating to confirmed when going back to
  uploads page
- Show Pending text based on confirmations instead of release time

Fix: #386