### PR TITLE
claim list: display publisher title instead of name

### DIFF
--- a/Odysee/Models/Claim.swift
+++ b/Odysee/Models/Claim.swift
@@ -192,4 +192,11 @@ class Claim: Decodable, Equatable, Hashable {
             return nil
         }
     }
+
+    var titleOrName: String? {
+        if let value, let title = value.title {
+            return title
+        }
+        return name
+    }
 }

--- a/Odysee/UI/ClaimTableViewCell.swift
+++ b/Odysee/UI/ClaimTableViewCell.swift
@@ -117,8 +117,8 @@ class ClaimTableViewCell: UITableViewCell {
         thumbnailImageView.isHidden = isChannel
 
         titleLabel.textColor = actualClaim.featured ? UIColor.white : nil
-        titleLabel.text = isChannel ? actualClaim.name : actualClaim.value?.title
-        publisherLabel.text = isChannel ? actualClaim.name : actualClaim.signingChannel?.name
+        titleLabel.text = actualClaim.value?.title
+        publisherLabel.text = isChannel ? actualClaim.name : actualClaim.signingChannel?.titleOrName
 
         let isLivestream = actualClaim.value?.source == nil && !isChannel
         if isLivestream {

--- a/Odysee/UI/LivestreamCollectionViewCell.swift
+++ b/Odysee/UI/LivestreamCollectionViewCell.swift
@@ -43,7 +43,7 @@ class LivestreamCollectionViewCell: UICollectionViewCell {
         startTimeLabel.textColor = claim.featured ? UIColor.white : nil
 
         titleLabel.text = claim.name
-        publisherLabel.text = claim.signingChannel?.name
+        publisherLabel.text = claim.signingChannel?.titleOrName
 
         // load thumbnail url
         if let thumbnailUrl = claim.value?.thumbnail?.url.flatMap(URL.init) {


### PR DESCRIPTION
Also put channel title on top and channel name as publisher when previewing channel claims (in claim list).