### PR TITLE
Active & Future livestreams on Channel page

### DIFF
--- a/Odysee/ClaimTableViewCell.xib
+++ b/Odysee/ClaimTableViewCell.xib
@@ -135,6 +135,33 @@
                             <constraint firstItem="Hf0-B9-1iQ" firstAttribute="top" secondItem="CUj-Lg-9sX" secondAttribute="bottom" constant="4" id="v44-Fp-ZOe"/>
                         </constraints>
                     </view>
+                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="tLo-Ey-cJD" userLabel="Viewer Count Stack View">
+                        <rect key="frame" x="122" y="67" width="50" height="27"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bjo-7d-dop" userLabel="Viewer Count Label">
+                                <rect key="frame" x="4" y="4" width="11" height="19"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cF3-Nr-JUt" userLabel="Viewer Count Image View">
+                                <rect key="frame" x="19" y="5.5" width="27" height="15.5"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <imageReference key="image" image="eye.fill" catalog="system" symbolScale="default"/>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="27" id="0c2-Za-J79"/>
+                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="96" id="niB-UL-tsI"/>
+                        </constraints>
+                        <edgeInsets key="layoutMargins" top="4" left="4" bottom="4" right="4"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                <integer key="value" value="6"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kWD-HC-WRW">
                         <rect key="frame" x="138" y="76.5" width="34" height="17.5"/>
                         <subviews>
@@ -157,6 +184,7 @@
                     <constraint firstItem="0fu-ke-6es" firstAttribute="top" secondItem="Org-uQ-egP" secondAttribute="top" constant="8" id="9HN-8o-7Tz"/>
                     <constraint firstItem="yAm-Wl-rdb" firstAttribute="bottom" secondItem="0fu-ke-6es" secondAttribute="bottom" id="AWY-U2-L5L"/>
                     <constraint firstItem="yAm-Wl-rdb" firstAttribute="top" secondItem="0fu-ke-6es" secondAttribute="top" id="HQp-bV-jD9"/>
+                    <constraint firstItem="hHl-9P-jcE" firstAttribute="leading" secondItem="tLo-Ey-cJD" secondAttribute="trailing" constant="20" id="Kix-mr-z0y"/>
                     <constraint firstItem="0vb-P0-JDM" firstAttribute="centerY" secondItem="Org-uQ-egP" secondAttribute="centerY" id="OQf-Ny-6AQ"/>
                     <constraint firstItem="0vb-P0-JDM" firstAttribute="leading" secondItem="Org-uQ-egP" secondAttribute="leading" constant="51" id="Pg9-dL-KSa"/>
                     <constraint firstItem="thG-V7-pbT" firstAttribute="height" secondItem="0fu-ke-6es" secondAttribute="height" multiplier="0.222222" id="QDe-1m-oBR"/>
@@ -166,6 +194,7 @@
                     <constraint firstItem="hHl-9P-jcE" firstAttribute="leading" secondItem="kWD-HC-WRW" secondAttribute="trailing" constant="20" id="ZCK-mT-gi1"/>
                     <constraint firstItem="hHl-9P-jcE" firstAttribute="centerY" secondItem="0fu-ke-6es" secondAttribute="centerY" id="ach-VE-nTf"/>
                     <constraint firstItem="fS2-h1-1ZT" firstAttribute="bottom" secondItem="0fu-ke-6es" secondAttribute="bottom" constant="-4" id="bI5-MN-etB"/>
+                    <constraint firstAttribute="bottom" secondItem="tLo-Ey-cJD" secondAttribute="bottom" constant="12" id="dha-CK-uDS"/>
                     <constraint firstAttribute="bottom" secondItem="kWD-HC-WRW" secondAttribute="bottom" constant="12" id="ksG-9I-Mzp"/>
                     <constraint firstAttribute="trailing" secondItem="hHl-9P-jcE" secondAttribute="trailing" constant="16" id="kzQ-sl-6Eq"/>
                     <constraint firstItem="hHl-9P-jcE" firstAttribute="top" secondItem="Org-uQ-egP" secondAttribute="top" constant="8" id="ywS-nn-7Mp"/>
@@ -183,11 +212,15 @@
                 <outlet property="publisherLabel" destination="Hf0-B9-1iQ" id="tg7-n4-F4S"/>
                 <outlet property="thumbnailImageView" destination="0fu-ke-6es" id="Alj-3n-8j1"/>
                 <outlet property="titleLabel" destination="CUj-Lg-9sX" id="JBG-b1-Gfs"/>
+                <outlet property="viewerCountImageView" destination="cF3-Nr-JUt" id="tOx-am-aL0"/>
+                <outlet property="viewerCountLabel" destination="bjo-7d-dop" id="8jM-rV-gmU"/>
+                <outlet property="viewerCountStackView" destination="tLo-Ey-cJD" id="E1E-Nu-mew"/>
             </connections>
             <point key="canvasLocation" x="133" y="1"/>
         </tableViewCell>
     </objects>
     <resources>
+        <image name="eye.fill" catalog="system" width="128" height="80"/>
         <image name="lock" catalog="system" width="125" height="128"/>
         <image name="lock.open" catalog="system" width="128" height="110"/>
         <systemColor name="labelColor">

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -212,7 +212,7 @@ class HomeViewController: UIViewController,
             return
         }
 
-        OdyseeLivestream.listLivestreams { result in
+        OdyseeLivestream.all { result in
             if case let .success(infos) = result {
                 self.livestreamInfos = infos.sorted {
                     $1.viewerCount < $0.viewerCount
@@ -354,7 +354,11 @@ class HomeViewController: UIViewController,
         ) as! LivestreamCollectionViewCell
 
         let livestream = livestreams[indexPath.row]
-        cell.setInfo(claim: livestream.claim, startTime: livestream.startTime, viewerCount: livestream.viewerCount)
+        cell.setLivestreamInfo(
+            claim: livestream.claim,
+            startTime: livestream.startTime,
+            viewerCount: livestream.viewerCount
+        )
 
         return cell
     }

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -563,10 +563,10 @@ class HomeViewController: UIViewController,
         livestreamsLabel.numberOfLines = 0
         let titleHeight = livestreamsLabel.intrinsicContentSize.height
 
-        let collectionViewFrame = CGRect(x: 0, y: 0, width: 0, height: 233)
+        let collectionViewFrame = CGRect(x: 0, y: 0, width: 0, height: 199)
         let collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .horizontal
-        collectionViewLayout.itemSize = CGSize(width: 256, height: 213)
+        collectionViewLayout.itemSize = CGSize(width: 196, height: 199)
         collectionViewLayout.sectionInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
 
         livestreamsCollectionView = UICollectionView(
@@ -584,7 +584,7 @@ class HomeViewController: UIViewController,
             forCellWithReuseIdentifier: "livestream_cell"
         )
 
-        let livestreamsViewFrame = CGRect(x: 0, y: 0, width: 0, height: 233 + titleHeight)
+        let livestreamsViewFrame = CGRect(x: 0, y: 0, width: 0, height: 199 + titleHeight)
         livestreamsView = UIStackView(frame: livestreamsViewFrame)
         livestreamsView.axis = .vertical
         livestreamsView.alignment = .trailing // HACK to prevent conflicting leading constraint

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -206,90 +206,88 @@ class HomeViewController: UIViewController,
         loadingContainer.isHidden = false
         loadingLivestreams = true
 
-        DispatchQueue.global().async { [self] in
-            OdyseeLivestream.listLivestreams { result in
-                if case var .success(infos) = result {
-                    let isWildWest = currentCategoryIndex == Self.categoryIndexWildWest
-                    if !isWildWest {
-                        infos = infos
-                            .filter { channelIds[currentCategoryIndex]?.contains($0.value.channelClaimId) ?? false }
+        OdyseeLivestream.listLivestreams { [self] result in
+            if case var .success(infos) = result {
+                let isWildWest = currentCategoryIndex == Self.categoryIndexWildWest
+                if !isWildWest {
+                    infos = infos
+                        .filter { channelIds[currentCategoryIndex]?.contains($0.value.channelClaimId) ?? false }
 
-                        guard infos.count > 0 else {
-                            DispatchQueue.main.async {
-                                claimListView.tableHeaderView = nil
-                                if !loadingClaims {
-                                    loadingContainer.isHidden = true
-                                }
-                                loadingLivestreams = false
-                            }
-                            return
-                        }
-                    } else {
-                        guard infos.count > 0 else {
-                            // Livestreams are "expected" in Wild West so show no livestreams message
-                            DispatchQueue.main.async {
-                                claimListView.tableHeaderView = livestreamsView
-                                livestreamsCollectionView.isHidden = true
-                                livestreamsLabel.text = String
-                                    .localized("No livestreams to display at this time. Please try again later.")
-                                if !loadingClaims {
-                                    loadingContainer.isHidden = true
-                                }
-                                loadingLivestreams = false
-                            }
-                            return
-                        }
-                    }
-
-                    DispatchQueue.main.async {
-                        claimListView.tableHeaderView = livestreamsView
-                        livestreamsCollectionView.isHidden = false
-                        livestreamsLabel.text = String.localized("Livestreams")
-                    }
-
-                    Lbry.apiCall(
-                        method: Lbry.Methods.claimSearch,
-                        params: .init(
-                            claimType: [.stream],
-                            page: livestreamsCurrentPage,
-                            pageSize: pageSize,
-                            hasNoSource: true,
-                            notTags: Constants.MatureTags + (isWildWest ? [] : [Constants.MembersOnly]),
-                            notChannelIds: isWildWest ? wildWestExcludedChannelIds : nil,
-                            claimIds: Array(infos.keys)
-                        )
-                    ).subscribeResult { result in
-                        if case let .success(payload) = result {
-                            let oldCount = livestreams.count
-                            for claim in payload.items {
-                                let livestreamInfo = infos[claim.claimId!]
-                                let livestreamData = LivestreamData(
-                                    startTime: livestreamInfo?.startTime ?? Date(),
-                                    viewerCount: livestreamInfo?.viewerCount ?? 0,
-                                    claim: claim
-                                )
-                                livestreams.append(livestreamData)
-                            }
-                            livestreams.sort {
-                                $1.viewerCount < $0.viewerCount
-                            }
-                            if livestreams.count != oldCount {
-                                livestreamsCollectionView.reloadData()
-                            }
-
-                            livestreamsLastPageReached = payload.isLastPage
-
+                    guard infos.count > 0 else {
+                        DispatchQueue.main.async { [self] in
+                            claimListView.tableHeaderView = nil
                             if !loadingClaims {
                                 loadingContainer.isHidden = true
                             }
                             loadingLivestreams = false
                         }
+                        return
                     }
-                } else if case let .failure(error) = result {
-                    DispatchQueue.main.async {
-                        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-                        appDelegate.mainController.showError(message: error.localizedDescription)
+                } else {
+                    guard infos.count > 0 else {
+                        // Livestreams are "expected" in Wild West so show no livestreams message
+                        DispatchQueue.main.async { [self] in
+                            claimListView.tableHeaderView = livestreamsView
+                            livestreamsCollectionView.isHidden = true
+                            livestreamsLabel.text = String
+                                .localized("No livestreams to display at this time. Please try again later.")
+                            if !loadingClaims {
+                                loadingContainer.isHidden = true
+                            }
+                            loadingLivestreams = false
+                        }
+                        return
                     }
+                }
+
+                DispatchQueue.main.async { [self] in
+                    claimListView.tableHeaderView = livestreamsView
+                    livestreamsCollectionView.isHidden = false
+                    livestreamsLabel.text = String.localized("Livestreams")
+                }
+
+                Lbry.apiCall(
+                    method: Lbry.Methods.claimSearch,
+                    params: .init(
+                        claimType: [.stream],
+                        page: livestreamsCurrentPage,
+                        pageSize: pageSize,
+                        hasNoSource: true,
+                        notTags: Constants.MatureTags + (isWildWest ? [] : [Constants.MembersOnly]),
+                        notChannelIds: isWildWest ? wildWestExcludedChannelIds : nil,
+                        claimIds: Array(infos.keys)
+                    )
+                ).subscribeResult { [self] result in
+                    if case let .success(payload) = result {
+                        let oldCount = livestreams.count
+                        for claim in payload.items {
+                            let livestreamInfo = infos[claim.claimId!]
+                            let livestreamData = LivestreamData(
+                                startTime: livestreamInfo?.startTime ?? Date(),
+                                viewerCount: livestreamInfo?.viewerCount ?? 0,
+                                claim: claim
+                            )
+                            livestreams.append(livestreamData)
+                        }
+                        livestreams.sort {
+                            $1.viewerCount < $0.viewerCount
+                        }
+                        if livestreams.count != oldCount {
+                            livestreamsCollectionView.reloadData()
+                        }
+
+                        livestreamsLastPageReached = payload.isLastPage
+
+                        if !loadingClaims {
+                            loadingContainer.isHidden = true
+                        }
+                        loadingLivestreams = false
+                    }
+                }
+            } else if case let .failure(error) = result {
+                DispatchQueue.main.async {
+                    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+                    appDelegate.mainController.showError(message: error.localizedDescription)
                 }
             }
         }

--- a/Odysee/LivestreamCollectionViewCell.xib
+++ b/Odysee/LivestreamCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -13,21 +13,21 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="1Sn-9G-gHi" customClass="LivestreamCollectionViewCell" customModule="Odysee" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="256" height="213"/>
+            <rect key="frame" x="0.0" y="0.0" width="196" height="153"/>
             <autoresizingMask key="autoresizingMask"/>
             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ThH-Aw-3Pm">
-                <rect key="frame" x="0.0" y="0.0" width="256" height="213"/>
+                <rect key="frame" x="0.0" y="0.0" width="196" height="153"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="I4k-sK-dVx" userLabel="Thumbnail Image View">
-                        <rect key="frame" x="8" y="0.0" width="240" height="135"/>
+                        <rect key="frame" x="8" y="0.0" width="180" height="101"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="240" id="LwK-k6-m7M"/>
-                            <constraint firstAttribute="height" constant="135" id="okv-nU-f0k"/>
+                            <constraint firstAttribute="width" constant="180" id="LwK-k6-m7M"/>
+                            <constraint firstAttribute="height" constant="101" id="okv-nU-f0k"/>
                         </constraints>
                     </imageView>
                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1zh-Io-5e4" userLabel="Has Access View">
-                        <rect key="frame" x="12" y="107" width="30" height="24"/>
+                        <rect key="frame" x="12" y="73" width="30" height="24"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="lock.open" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="tia-uW-bRC">
                                 <rect key="frame" x="0.0" y="2.5" width="30" height="18.5"/>
@@ -46,32 +46,32 @@
                         </userDefinedRuntimeAttributes>
                     </stackView>
                     <visualEffectView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cd0-wc-daO" userLabel="Members Only View">
-                        <rect key="frame" x="8" y="0.0" width="240" height="135"/>
+                        <rect key="frame" x="8" y="0.0" width="180" height="101"/>
                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="QQb-0l-EEK">
-                            <rect key="frame" x="0.0" y="0.0" width="240" height="135"/>
+                            <rect key="frame" x="0.0" y="0.0" width="180" height="101"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="lKL-k5-Hkc">
-                                    <rect key="frame" x="4" y="4" width="232" height="127"/>
+                                    <rect key="frame" x="4" y="4" width="172" height="93"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="lock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="EV4-lp-Sun">
-                                            <rect key="frame" x="0.0" y="0.5" width="232" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.5" width="172" height="31"/>
                                             <color key="tintColor" systemColor="labelColor"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Members Only" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkh-rT-7NH">
-                                            <rect key="frame" x="0.0" y="48.5" width="232" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="36.5" width="172" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Join on odysee.com" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fME-Pl-6Nk">
-                                            <rect key="frame" x="0.0" y="73" width="232" height="17"/>
+                                            <rect key="frame" x="0.0" y="61" width="172" height="17"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xG0-RX-hNM">
-                                            <rect key="frame" x="0.0" y="94" width="232" height="33"/>
+                                            <rect key="frame" x="0.0" y="82" width="172" height="11"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </view>
                                     </subviews>
@@ -90,7 +90,7 @@
                         <blurEffect style="regular"/>
                     </visualEffectView>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="kVA-ic-4Ua" userLabel="Viewer Count Stack View">
-                        <rect key="frame" x="190" y="100" width="50" height="27"/>
+                        <rect key="frame" x="130" y="66" width="50" height="27"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qNZ-GY-bIA" userLabel="Viewer Count Label">
                                 <rect key="frame" x="4" y="4" width="11" height="19"/>
@@ -117,7 +117,7 @@
                         </userDefinedRuntimeAttributes>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="beA-GF-cHg">
-                        <rect key="frame" x="8" y="143" width="240" height="70"/>
+                        <rect key="frame" x="8" y="109" width="180" height="44"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xOY-ev-iQf" userLabel="Title Label">
                                 <rect key="frame" x="0.0" y="0.0" width="37" height="17"/>
@@ -146,7 +146,7 @@
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="K9g-9i-4X0" secondAttribute="trailing" id="Q1P-ld-hNs"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gU5-45-Rnz" secondAttribute="trailing" id="WAn-P7-00k"/>
                             <constraint firstItem="K9g-9i-4X0" firstAttribute="leading" secondItem="beA-GF-cHg" secondAttribute="leading" id="XtL-cZ-AKv"/>
-                            <constraint firstAttribute="width" constant="240" id="fYq-bC-gRd"/>
+                            <constraint firstAttribute="width" constant="180" id="fYq-bC-gRd"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xOY-ev-iQf" secondAttribute="trailing" id="ihH-cl-RSe"/>
                             <constraint firstItem="gU5-45-Rnz" firstAttribute="leading" secondItem="beA-GF-cHg" secondAttribute="leading" id="qqd-S9-pgL"/>
                         </constraints>

--- a/Odysee/LivestreamCollectionViewCell.xib
+++ b/Odysee/LivestreamCollectionViewCell.xib
@@ -98,7 +98,7 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="P8t-uf-2lA" userLabel="Image View">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="P8t-uf-2lA" userLabel="Viewer Count Image View">
                                 <rect key="frame" x="19" y="5.5" width="27" height="15.5"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <imageReference key="image" image="eye.fill" catalog="system" symbolScale="default"/>
@@ -175,6 +175,7 @@
                 <outlet property="startTimeLabel" destination="K9g-9i-4X0" id="3oY-7v-1gC"/>
                 <outlet property="thumbnailImageView" destination="I4k-sK-dVx" id="GIi-XS-N4W"/>
                 <outlet property="titleLabel" destination="xOY-ev-iQf" id="toI-Jr-bfg"/>
+                <outlet property="viewerCountImageView" destination="P8t-uf-2lA" id="uYE-n4-gUi"/>
                 <outlet property="viewerCountLabel" destination="qNZ-GY-bIA" id="sg6-HW-y0p"/>
                 <outlet property="viewerCountStackView" destination="kVA-ic-4Ua" id="HMl-YR-c31"/>
             </connections>

--- a/Odysee/UI/LivestreamCollectionViewCell.swift
+++ b/Odysee/UI/LivestreamCollectionViewCell.swift
@@ -28,6 +28,21 @@ class LivestreamCollectionViewCell: UICollectionViewCell {
         let publisherTapGesture = UITapGestureRecognizer(target: self, action: #selector(publisherTapped(_:)))
         publisherLabel.addGestureRecognizer(publisherTapGesture)
         thumbnailImageView.backgroundColor = Helper.lightPrimaryColor
+
+        if #available(iOS 14, *) {
+        } else {
+            let viewerCountBackground = UIView()
+            viewerCountBackground.backgroundColor = Helper.primaryColor
+            viewerCountBackground.layer.cornerRadius = 6
+            viewerCountBackground.translatesAutoresizingMaskIntoConstraints = false
+            viewerCountStackView.insertSubview(viewerCountBackground, at: 0)
+            NSLayoutConstraint.activate([
+                viewerCountBackground.leadingAnchor.constraint(equalTo: viewerCountStackView.leadingAnchor),
+                viewerCountBackground.trailingAnchor.constraint(equalTo: viewerCountStackView.trailingAnchor),
+                viewerCountBackground.topAnchor.constraint(equalTo: viewerCountStackView.topAnchor),
+                viewerCountBackground.bottomAnchor.constraint(equalTo: viewerCountStackView.bottomAnchor)
+            ])
+        }
     }
 
     func setInfo(claim: Claim, startTime: Date, viewerCount: Int) {

--- a/Odysee/UI/LivestreamCollectionViewCell.swift
+++ b/Odysee/UI/LivestreamCollectionViewCell.swift
@@ -19,6 +19,7 @@ class LivestreamCollectionViewCell: UICollectionViewCell {
     @IBOutlet var membersOnlyView: UIView!
     @IBOutlet var viewerCountStackView: UIStackView!
     @IBOutlet var viewerCountLabel: UILabel!
+    @IBOutlet var viewerCountImageView: UIImageView!
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var publisherLabel: UILabel!
     @IBOutlet var startTimeLabel: UILabel!
@@ -72,7 +73,12 @@ class LivestreamCollectionViewCell: UICollectionViewCell {
         let startTimeRelative = Helper.fullRelativeDateFormatter.localizedString(for: startTime, relativeTo: Date())
         startTimeLabel.text = "Started \(startTimeRelative)"
 
-        viewerCountLabel.text = String(viewerCount)
+        viewerCountImageView.isHidden = viewerCount == 0
+        if viewerCount > 0 {
+            viewerCountLabel.text = String(viewerCount)
+        } else {
+            viewerCountLabel.text = "LIVE"
+        }
 
         if claim.value?.tags?.contains(Constants.MembersOnly) ?? false {
             DispatchQueue.global().async {

--- a/Odysee/Utils/OdyseeLivestream.swift
+++ b/Odysee/Utils/OdyseeLivestream.swift
@@ -8,17 +8,18 @@
 import Foundation
 
 struct OdyseeLivestream {
-    static let apiEndpoint = URL(string: "https://api.odysee.live/livestream/all")!
+    static let allEndpoint = URL(string: "https://api.odysee.live/livestream/all")!
+    static let isLiveEndpoint = "https://api.odysee.live/livestream/is_live?channel_claim_id=%@"
 
-    static func listLivestreams(completion: @escaping (_ result: Result<[LivestreamInfo], Error>) -> Void) {
+    static func all(completion: @escaping (_ result: Result<[LivestreamInfo], Error>) -> Void) {
         DispatchQueue.global().async {
             do {
-                let data = try Data(contentsOf: apiEndpoint)
+                let data = try Data(contentsOf: allEndpoint)
 
                 let decoder = JSONDecoder()
                 decoder.dateDecodingStrategy = .iso8601
 
-                let result = try decoder.decode(OLResult.self, from: data)
+                let result = try decoder.decode(OLAllResult.self, from: data)
                 if result.success, result.error == nil, let data = result.data {
                     let livestreamInfos = data
                         .filter { $0.activeClaim.claimId != "Confirming" }
@@ -41,19 +42,74 @@ struct OdyseeLivestream {
                     completion(.failure(OdyseeLivestreamError.runtimeError("\(error)\n---Trace---\n\(trace)")))
                     return
                 }
+
+                completion(.failure(OdyseeLivestreamError.unknown))
             } catch {
                 completion(.failure(error))
-                return
             }
-
-            completion(.failure(OdyseeLivestreamError.noBranchTaken))
         }
     }
 
-    struct OLResult: Decodable {
+    static func channelIsLive(
+        channelClaimId: String,
+        completion: @escaping (_ result: Result<ChannelLiveInfo, Error>) -> Void
+    ) {
+        DispatchQueue.global().async {
+            do {
+                guard let url = URL(string: String(format: isLiveEndpoint, channelClaimId)) else {
+                    completion(.failure(OdyseeLivestreamError.couldNotCreateUrl))
+                    return
+                }
+
+                let data = try Data(contentsOf: url)
+
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+
+                let result = try decoder.decode(OLIsLiveResult.self, from: data)
+                if result.success, result.error == nil, let data = result.data {
+                    completion(.success(ChannelLiveInfo(
+                        live: data.live,
+                        startTime: data.startTime,
+                        viewerCount: data.viewerCount,
+                        channelClaimId: data.channelClaimId,
+                        activeClaimUrl: data.activeClaim.canonicalUrl,
+                        futureClaimsUrls: data.futureClaims?.map(\.canonicalUrl)
+                    )))
+                    return
+                } else if result.data == nil,
+                          let error = result.error,
+                          let trace = result.trace
+                {
+                    completion(.failure(OdyseeLivestreamError.runtimeError("\(error)\n---Trace---\n\(trace)")))
+                    return
+                }
+
+                completion(.failure(OdyseeLivestreamError.unknown))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    struct OLAllResult: Decodable {
         var success: Bool
         var error: String?
         var data: [OLLivestream]?
+        var trace: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case success
+            case error
+            case data
+            case trace = "_trace"
+        }
+    }
+
+    struct OLIsLiveResult: Decodable {
+        var success: Bool
+        var error: String?
+        var data: OLLivestream?
         var trace: [String]?
 
         enum CodingKeys: String, CodingKey {
@@ -70,6 +126,7 @@ struct OdyseeLivestream {
         var viewerCount: Int
         var channelClaimId: String
         var activeClaim: OLClaim
+        var futureClaims: [OLClaim]?
 
         enum CodingKeys: String, CodingKey {
             case live = "Live"
@@ -77,14 +134,17 @@ struct OdyseeLivestream {
             case viewerCount = "ViewerCount"
             case channelClaimId = "ChannelClaimID"
             case activeClaim = "ActiveClaim"
+            case futureClaims = "FutureClaims"
         }
     }
 
     struct OLClaim: Decodable {
         var claimId: String
+        var canonicalUrl: String
 
         enum CodingKeys: String, CodingKey {
             case claimId = "ClaimID"
+            case canonicalUrl = "CanonicalURL"
         }
     }
 }
@@ -96,6 +156,16 @@ struct LivestreamInfo {
     var activeClaimId: String
 }
 
+struct ChannelLiveInfo {
+    var live: Bool
+    var startTime: Date
+    var viewerCount: Int
+    var channelClaimId: String
+    var activeClaimUrl: String
+    var futureClaimsUrls: [String]?
+}
+
+/// Used by external files for associating claims with details about them as a livestream
 struct LivestreamData: Hashable {
     var startTime: Date
     var viewerCount: Int
@@ -103,13 +173,16 @@ struct LivestreamData: Hashable {
 }
 
 enum OdyseeLivestreamError: LocalizedError {
-    case noBranchTaken
+    case unknown
+    case couldNotCreateUrl
     case runtimeError(String)
 
     var errorDescription: String? {
         switch self {
-        case .noBranchTaken:
-            return String.localized("No result logic branch taken")
+        case .unknown:
+            return String.localized("Unknown error occurred")
+        case .couldNotCreateUrl:
+            return String.localized("Endpoint URL could not be created")
         case let .runtimeError(message):
             return String(format: String.localized("Runtime error: %@"), message)
         }


### PR DESCRIPTION
A bunch of small changes + refactoring + the big change of livestreams on the channel page.

Notable UI changes:
- Fetch livestreams in Wild West/other home tabs only once (previously it would fetch each time, instead of just running claim_search). This fixes the livestreams jumping around as they get sorted after fetching more.
- Fix no background color on viewer count view in livestream cell (on iOS 13)
- Make livestream cell smaller so it's more similar to claim cell. Titles wrap across two lines (already did previously but it's noticable now)

Screenshot of channel page with active & future livestreams:
<img height=500 alt="Odysee Channel page with active and future livestreams" src="https://user-images.githubusercontent.com/71804605/196371322-b572da5e-0f4f-4e51-a8a8-b8fbf2d7e660.png">
