### PR TITLE
AppDelegate: remove remote transport controls when closing miniplayer

### DIFF
--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -263,9 +263,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
             appDelegate.lazyPlayer = nil
 
             appDelegate.resetPlayerObserver()
-
-            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
-            UIApplication.shared.endReceivingRemoteControlEvents()
+            appDelegate.removeRemoteTransportControls()
         }
 
         miniPlayerTitleLabel.text = ""


### PR DESCRIPTION
When replacing the currently playing claim, the miniplayer gets closed, then remote transport controls get added, but the previous ones aren't removed, so togglePlayPause gets called multiple times, causing the player to not play/pause but instead quickly play and pause.

Fix: #400