### PR TITLE
URIs with Unicode fixes

### DIFF
--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -796,12 +796,17 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                     }
 
                     if let result = data["result"] as? [String: Any] {
-                        if let contentUrl = result["streaming_url"] as? String {
+                        if let streamingUrl = result["streaming_url"] as? String,
+                           let contentUrl = URL(
+                               string: streamingUrl
+                                   .addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
+                           )
+                        {
                             DispatchQueue.main.async {
                                 self.displayClaimContentFromUrl(
                                     singleClaim: singleClaim,
                                     contentType: contentType!,
-                                    contentUrl: URL(string: contentUrl)
+                                    contentUrl: contentUrl
                                 )
                             }
                         }

--- a/Odysee/Utils/LbryUri.swift
+++ b/Odysee/Utils/LbryUri.swift
@@ -116,7 +116,7 @@ struct LbryUri: CustomStringConvertible {
         )
         if results.count > 0 {
             for index in 1 ..< results[0].numberOfRanges {
-                components.append(String(cleanUrl[Range(results[0].range(at: index), in: cleanUrl)!]))
+                components.append((cleanUrl as NSString).substring(with: results[0].range(at: index)))
             }
         }
 


### PR DESCRIPTION
Use `NSString.substring(with:)` for getting regex groups

Fix: #279
Fix: #429
Supersedes: #394 (Still keep this around as switching to Swift 5.7 Regex simplifies a lot of code)

---

Percent encode URLs for fetching non-video content