### PR TITLE
fix: playback rate

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -53,7 +53,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func registerPlayerObserver() {
         if let lazyPlayer = lazyPlayer, !playerObserverAdded {
-            lazyPlayer.addObserver(self, forKeyPath: "timeControlStatus", options: [.old, .new], context: nil)
             lazyPlayer.currentItem?.addObserver(
                 self,
                 forKeyPath: "playbackLikelyToKeepUp",
@@ -92,19 +91,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         change: [NSKeyValueChangeKey: Any]?,
         context: UnsafeMutableRawPointer?
     ) {
-        if object as AnyObject? === lazyPlayer, currentTimeControlStatus != lazyPlayer?.timeControlStatus {
-            currentTimeControlStatus = lazyPlayer?.timeControlStatus
-            if keyPath == "timeControlStatus", lazyPlayer?.timeControlStatus == .playing {
-                if let currentFileViewController = currentFileViewController {
-                    currentFileViewController.checkTimeToStart()
-                    DispatchQueue.main.async {
-                        self.lazyPlayer?.rate = currentFileViewController.playerRate
-                    }
-                }
-                return
-            }
-        }
-
         if let player = lazyPlayer,
            let item = player.currentItem,
            keyPath == "playbackLikelyToKeepUp",


### PR DESCRIPTION
Resolves #527
removed timeControlStatus observer due to playerRate reversion to 1.0 when video playing resumes from any event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic playback behavior that was triggered by player state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->