### PR TITLE
vc(search): directly resolve valid LbryUri

### DIFF
--- a/Odysee/Controllers/Content/SearchViewController.swift
+++ b/Odysee/Controllers/Content/SearchViewController.swift
@@ -201,6 +201,18 @@ class SearchViewController: UIViewController,
         currentMediaTypes = mediaTypes
         currentTimeFilter = timeFilter
         currentSortBy = sortBy
+
+        if let uri = LbryUri.tryParse(url: query.trimmingCharacters(in: .whitespacesAndNewlines), requireProto: true),
+           !uri.channelName.isBlank || !uri.streamName.isBlank
+        {
+            Lbry.apiCall(
+                method: BackendMethods.resolve,
+                params: .init(urls: [uri.description])
+            )
+            .subscribeResult(didResolveResults)
+            return
+        }
+
         Lighthouse.search(
             rawQuery: query,
             size: pageSize,


### PR DESCRIPTION
Allow opening lbry:// channel URIs via search, as they are broken when coming from deep links.

Fix: #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search now detects channel or stream links (direct URIs) and resolves them immediately, returning faster, more accurate results for direct link queries instead of routing through the standard search path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->