### PR TITLE
AppDelegate: disable idle timer when media playing

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -279,8 +279,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
               let currentItem = lazyPlayer.currentItem,
               currentItem.status == .readyToPlay
         else {
+            UIApplication.shared.isIdleTimerDisabled = false
             return
         }
+
+        // Keep screen on when playing
+        UIApplication.shared.isIdleTimerDisabled = lazyPlayer.rate != 0
 
         (mainViewController as? MainViewController)?.miniPlayerPlayPauseButton.image = UIImage(
             systemName: lazyPlayer.rate == 0 ? "play.fill" : "pause.fill"


### PR DESCRIPTION
Fix: #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen will now remain active during video playback, preventing the device from sleeping while watching content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->