### PR TITLE
Clickable timestamps in description/comment

### DIFF
--- a/Odysee/Base.lproj/Main.storyboard
+++ b/Odysee/Base.lproj/Main.storyboard
@@ -7051,21 +7051,22 @@ Line 2</string>
                                                             <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i5q-Kz-cym">
-                                                            <rect key="frame" x="16" y="12" width="326" height="1"/>
+                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="C4T-TW-LdO">
+                                                            <rect key="frame" x="16" y="12" width="326" height="33"/>
+                                                            <color key="textColor" systemColor="labelColor"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
+                                                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                            <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                                                        </textView>
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="tUo-nT-AQC" secondAttribute="trailing" constant="16" id="PJK-th-RKY"/>
+                                                        <constraint firstItem="C4T-TW-LdO" firstAttribute="leading" secondItem="Tdm-6D-KDs" secondAttribute="leading" constant="16" id="Qin-EU-RXS"/>
                                                         <constraint firstItem="tUo-nT-AQC" firstAttribute="top" secondItem="Tdm-6D-KDs" secondAttribute="top" constant="8" id="TKE-AJ-vSl"/>
-                                                        <constraint firstItem="i5q-Kz-cym" firstAttribute="top" secondItem="tUo-nT-AQC" secondAttribute="bottom" constant="4" id="V7p-vS-Ken"/>
                                                         <constraint firstItem="tUo-nT-AQC" firstAttribute="leading" secondItem="Tdm-6D-KDs" secondAttribute="leading" constant="16" id="WwF-Qq-LdC"/>
-                                                        <constraint firstAttribute="trailing" secondItem="i5q-Kz-cym" secondAttribute="trailing" constant="16" id="fJ6-MK-Uya"/>
-                                                        <constraint firstItem="i5q-Kz-cym" firstAttribute="leading" secondItem="Tdm-6D-KDs" secondAttribute="leading" constant="16" id="hL1-fb-APp"/>
-                                                        <constraint firstAttribute="bottom" secondItem="i5q-Kz-cym" secondAttribute="bottom" constant="16" id="hme-2K-8Pt"/>
+                                                        <constraint firstAttribute="bottom" secondItem="C4T-TW-LdO" secondAttribute="bottom" constant="16" id="X0O-em-gtq"/>
+                                                        <constraint firstAttribute="trailing" secondItem="C4T-TW-LdO" secondAttribute="trailing" constant="16" id="dna-qe-0pF"/>
+                                                        <constraint firstItem="C4T-TW-LdO" firstAttribute="top" secondItem="tUo-nT-AQC" secondAttribute="bottom" constant="4" id="t3h-ok-YyF"/>
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zC3-Dh-Olm" userLabel="Comment Actions View">
@@ -7202,7 +7203,7 @@ Line 2</string>
                                             <outlet property="authorNameLabel" destination="tUo-nT-AQC" id="Let-Ae-cSR"/>
                                             <outlet property="authorThumbnailView" destination="3Pc-Ox-7bE" id="10R-g2-7Bt"/>
                                             <outlet property="blockChannelContainer" destination="3zf-3y-elz" id="qN5-Kn-Ai5"/>
-                                            <outlet property="commentBodyLabel" destination="i5q-Kz-cym" id="iVP-tJ-1rg"/>
+                                            <outlet property="commentBodyTextView" destination="C4T-TW-LdO" id="iVP-tJ-1rg"/>
                                             <outlet property="fireReactionContainer" destination="ak0-t2-bzd" id="QFK-gC-ZZd"/>
                                             <outlet property="fireReactionImage" destination="Oq4-95-IdW" id="Orb-vS-wRC"/>
                                             <outlet property="fireReactionLabel" destination="swc-uj-cgw" id="dRk-N3-zuB"/>

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -884,7 +884,13 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             titleAreaIconView.isHidden = true
         } else {
             // details
-            descriptionTextView.text = claim?.value?.description
+            if #available(iOS 16.0, *), let description = claim?.value?.description {
+                var attributedDescription = Helper.processTimestamps(description)
+                attributedDescription.uiKit.font = .systemFont(ofSize: 13)
+                descriptionTextView.attributedText = NSAttributedString(attributedDescription)
+            } else {
+                descriptionTextView.text = claim?.value?.description
+            }
         }
     }
 

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -885,6 +885,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         } else {
             // details
             if #available(iOS 16.0, *), let description = claim?.value?.description {
+                descriptionTextView.delegate = self
+
                 var attributedDescription = Helper.processTimestamps(description)
                 attributedDescription.uiKit.font = .systemFont(ofSize: 13)
                 descriptionTextView.attributedText = NSAttributedString(attributedDescription)
@@ -2524,6 +2526,24 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         }
 
         commentAsChannelLabel.text = String(format: String.localized("Comment as %@"), name)
+    }
+
+    func textView(
+        _ textView: UITextView,
+        shouldInteractWith url: URL,
+        in characterRange: NSRange,
+        interaction: UITextItemInteraction
+    ) -> Bool {
+        if interaction == .invokeDefaultAction,
+           url.absoluteString.hasPrefix("?t="),
+           let seconds = CMTimeValue(url.absoluteString.dropFirst(3)),
+           let player = avpc.player
+        {
+            player.seek(to: CMTime(value: seconds, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
+            return false
+        }
+
+        return true
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Odysee/UI/CommentTableViewCell.swift
+++ b/Odysee/UI/CommentTableViewCell.swift
@@ -84,6 +84,8 @@ class CommentTableViewCell: UITableViewCell {
 
         authorNameLabel.text = comment.channelName
         if #available(iOS 16.0, *), let commentText = comment.comment {
+            commentBodyTextView.delegate = AppDelegate.shared.currentFileViewController
+
             var attributedComment = Helper.processTimestamps(commentText)
             attributedComment.uiKit.font = .systemFont(ofSize: 13)
             commentBodyTextView.attributedText = NSAttributedString(attributedComment)

--- a/Odysee/UI/CommentTableViewCell.swift
+++ b/Odysee/UI/CommentTableViewCell.swift
@@ -15,7 +15,7 @@ class CommentTableViewCell: UITableViewCell {
 
     @IBOutlet var authorThumbnailView: UIImageView!
     @IBOutlet var authorNameLabel: UILabel!
-    @IBOutlet var commentBodyLabel: UILabel!
+    @IBOutlet var commentBodyTextView: UITextView!
     @IBOutlet var replyCountButton: UIButton!
 
     @IBOutlet var fireReactionContainer: UIView!
@@ -60,6 +60,9 @@ class CommentTableViewCell: UITableViewCell {
     }
 
     func setComment(comment: Comment) {
+        commentBodyTextView.textContainer.lineFragmentPadding = 0
+        commentBodyTextView.textContainerInset = .zero
+
         if let currentComment, comment.commentId != currentComment.commentId {
             authorThumbnailView.image = UIImage(named: "spaceman")
             authorThumbnailView.backgroundColor = Helper.lightPrimaryColor
@@ -80,7 +83,13 @@ class CommentTableViewCell: UITableViewCell {
         )
 
         authorNameLabel.text = comment.channelName
-        commentBodyLabel.text = comment.comment
+        if #available(iOS 16.0, *), let commentText = comment.comment {
+            var attributedComment = Helper.processTimestamps(commentText)
+            attributedComment.uiKit.font = .systemFont(ofSize: 13)
+            commentBodyTextView.attributedText = NSAttributedString(attributedComment)
+        } else {
+            commentBodyTextView.text = comment.comment
+        }
         fireReactionLabel.text = String(describing: comment.numLikes ?? 0)
         if fireReactionLabel.text.isEmpty {
             fireReactionLabel.text = "0"

--- a/Odysee/Utils/Helper.swift
+++ b/Odysee/Utils/Helper.swift
@@ -9,6 +9,7 @@ import Base58Swift
 import CoreActionSheetPicker
 import FirebaseCrashlytics
 import Foundation
+import RegexBuilder
 import UIKit
 
 enum Helper {
@@ -402,6 +403,73 @@ enum Helper {
     @MainActor
     static func showError(error: Error) {
         (AppDelegate.shared.mainViewController as? MainViewController)?.showError(error: error)
+    }
+
+    @available(iOS 16.0, *)
+    static func processTimestamps(_ str: String) -> AttributedString {
+        str
+            .ranges {
+                Regex {
+                    OneOrMore {
+                        ChoiceOf {
+                            /[0-9]/
+
+                            ":"
+                        }
+                    }
+
+                    // Don't end with :
+                    /[0-9]/
+                }
+            }
+            /// <https://github.com/OdyseeTeam/odysee-frontend/blob/ffb6c71312d33abbdc6cd5e3aad4e589ba657960/ui/util/remark-timestamp.js#L43-L61>
+            .filter { range in
+                do {
+                    let s = String(str[range])
+                    switch s.count {
+                    case 4: // "9:59"
+                        return try /^[0-9]:[0-5][0-9]$/.wholeMatch(in: s) != nil
+                    case 5: // "59:59"
+                        return try /^[0-5][0-9]:[0-5][0-9]$/.wholeMatch(in: s) != nil
+                    case 7: // "9:59:59"
+                        return try /^[0-9]:[0-5][0-9]:[0-5][0-9]$/.wholeMatch(in: s) != nil
+                    case 8: // "99:59:59"
+                        return try /^[0-9][0-9]:[0-5][0-9]:[0-5][0-9]$/.wholeMatch(in: s) != nil
+                    default:
+                        return false
+                    }
+                } catch {
+                    return false
+                }
+            }
+            /// <https://github.com/OdyseeTeam/odysee-frontend/blob/ffb6c71312d33abbdc6cd5e3aad4e589ba657960/ui/util/remark-timestamp.js#L131-L134>
+            .compactMap { range -> ([Int], Range<String.Index>)? in
+                let timestampStrings = str[range].split(separator: ":").reversed().map(String.init)
+
+                let components = timestampStrings.compactMap(Int.init)
+
+                // If any timestamp components fail to parse, ignore
+                guard timestampStrings.count == components.count else {
+                    return nil
+                }
+
+                return (components, range)
+            }
+            .reduce(into: AttributedString(str)) { attr, timestamp in
+                let (components, range) = timestamp
+
+                let seconds = (components.count >= 3 ? components[2] : 0) * 60 * 60
+                    + (components.count >= 2 ? components[1] : 0) * 60
+                    + (components.count >= 1 ? components[0] : 0)
+
+                if let lower = AttributedString.Index(range.lowerBound, within: attr),
+                   let upper = AttributedString.Index(range.upperBound, within: attr),
+                   /// <https://github.com/OdyseeTeam/odysee-frontend/blob/ffb6c71312d33abbdc6cd5e3aad4e589ba657960/ui/util/remark-timestamp.js#L142>
+                   let url = URL(string: "?t=\(seconds)")
+                {
+                    attr[lower ..< upper].link = url
+                }
+            }
     }
 }
 


### PR DESCRIPTION
Fix: #532 (only for iOS 16+, not writing it for before iOS 15 with NSRegularExpression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timestamps in comments and video descriptions are interactive—tap any timestamp (e.g., 9:59) to jump directly to that moment.
  * Comments and descriptions now use improved text rendering with link detection for timestamps and other links.
* **Bug Fixes**
  * More reliable tapping/interaction handling for in-text timestamp links across iOS versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->