### PR TITLE
ui(file dismiss): only restore header visibility if previously visible

### DIFF
--- a/Odysee/Controllers/Content/FileDismissAnimationController.swift
+++ b/Odysee/Controllers/Content/FileDismissAnimationController.swift
@@ -8,6 +8,12 @@
 import UIKit
 
 class FileDismissAnimationController: NSObject, UIViewControllerAnimatedTransitioning {
+    let needRestoreHeader: Bool
+
+    init(needRestoreHeader: Bool) {
+        self.needRestoreHeader = needRestoreHeader
+    }
+
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return 0.5
     }
@@ -41,7 +47,9 @@ class FileDismissAnimationController: NSObject, UIViewControllerAnimatedTransiti
                 translationX: 0,
                 y: transitionContext.containerView.bounds.height
             )
-            AppDelegate.shared.mainController?.toggleHeaderVisibility(hidden: false)
+            if self.needRestoreHeader {
+                AppDelegate.shared.mainController?.toggleHeaderVisibility(hidden: false)
+            }
             AppDelegate.shared.mainController?.headerArea.alpha = 1
         } completion: { _ in
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -185,8 +185,15 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
 
     let availableRates = ["0.25x", "0.5x", "0.75x", "1x", "1.25x", "1.5x", "1.75x", "2x"]
 
+    var needRestoreHeader = false
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // If header is currently not hidden (assume not), then restore on dismiss
+        // Updating on every viewWillAppear is fine, as view will only reappear from miniPlayer, hence correct header
+        // Occasionally (e.g. multiple stacked file_vc) won't animate header reappearing, but will still appear
+        needRestoreHeader = !(AppDelegate.shared.mainController?.headerArea.isHidden ?? false)
 
         AppDelegate.shared.mainController?.toggleHeaderVisibility(hidden: true)
         if AppDelegate.shared.currentClaim == claim ||
@@ -2184,7 +2191,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         to toVC: UIViewController
     ) -> UIViewControllerAnimatedTransitioning? {
         if interactiveDismiss != nil {
-            return FileDismissAnimationController()
+            return FileDismissAnimationController(needRestoreHeader: needRestoreHeader)
         }
         return nil
     }


### PR DESCRIPTION
Fix: Popping file_vc above search causes header bar to appear on search
Fix: #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header visibility restoration behavior during file dismissal to properly respect the current navigation state, ensuring the app header is only restored when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->