### PR TITLE
fix: force landscape orientation on full-screen entry and portrait on exit

### DIFF
--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -812,7 +812,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
 
         completionHandler(true)
     }
-    
+
     func playerViewController(
         _ playerViewController: AVPlayerViewController,
         willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator


### PR DESCRIPTION
Resolves #540
Orients to landscape when full screen button mode and back to portrait when leaving full screen mode.
The above changes only apply if the device is in the portrait orientation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video player orientation handling during full‑screen transitions to prevent incorrect rotations and unwanted orientation states.
  * Resolved cases where playback stopped or behaved inconsistently when toggling full‑screen.

* **Improvements**
  * Smoother animations when entering and exiting full‑screen playback.
  * Improved playback continuity with immediate resume when switching screen modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->