### PR TITLE
vc(file): consider deleted signingChannel as Anonymous

### DIFF
--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -844,7 +844,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         var thumbnailUrl: URL?
         publisherImageView.rounded()
         livestreamerImageView.rounded()
-        if singleClaim.signingChannel != nil {
+        if (singleClaim.isChannelSignatureValid ?? false) && singleClaim.signingChannel != nil {
             if !isLivestream {
                 publisherTitleLabel.text = singleClaim.signingChannel?.value?.title
                 publisherNameLabel.text = singleClaim.signingChannel?.name


### PR DESCRIPTION
Fix: Claim with non-null signing channel but only has `channel_id`
https://odysee.com/Battle-Blaze-(SNES)-Playthrough---NintendoComplete:9