### PR TITLE
Lbryio: areCommentsEnabled use claimId and Optional channel info

### DIFF
--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -352,6 +352,7 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
             }
 
             Lbryio.areCommentsEnabled(
+                claimId: claimId,
                 channelId: claimId,
                 channelName: name,
                 completion: { enabled in

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -832,10 +832,11 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             avpcInitialised = true
         }
 
-        if let channelId = claim?.signingChannel?.claimId, let name = claim?.signingChannel?.name {
+        if let claimId = claim?.claimId {
             Lbryio.areCommentsEnabled(
-                channelId: channelId,
-                channelName: name,
+                claimId: claimId,
+                channelId: claim?.signingChannel?.claimId,
+                channelName: claim?.signingChannel?.name,
                 completion: { enabled in
                     self.commentsDisabledChecked = true
                     self.checkCommentsDisabled(commentsDisabled: !enabled, currentClaim: singleClaim)

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -749,7 +749,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         descriptionDivider.isHidden = true
 
         var contentType: String?
-        if let mediaType = claim?.value?.source?.mediaType {
+        if let mediaType = singleClaim.value?.source?.mediaType {
             isTextContent = mediaType.starts(with: "text/")
             isImageContent = mediaType.starts(with: "image/")
             isOtherContent = !isTextContent && !isImageContent && !mediaType.starts(with: "video") && !mediaType
@@ -832,11 +832,11 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             avpcInitialised = true
         }
 
-        if let claimId = claim?.claimId {
+        if let claimId = singleClaim.claimId {
             Lbryio.areCommentsEnabled(
                 claimId: claimId,
-                channelId: claim?.signingChannel?.claimId,
-                channelName: claim?.signingChannel?.name,
+                channelId: singleClaim.signingChannel?.claimId,
+                channelName: singleClaim.signingChannel?.name,
                 completion: { enabled in
                     self.commentsDisabledChecked = true
                     self.checkCommentsDisabled(commentsDisabled: !enabled, currentClaim: singleClaim)
@@ -901,7 +901,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             titleAreaIconView.isHidden = true
         } else {
             // details
-            if #available(iOS 16.0, *), let description = claim?.value?.description {
+            if #available(iOS 16.0, *), let description = singleClaim.value?.description {
                 descriptionTextView.delegate = self
 
                 var attributedDescription = Helper.processTimestamps(description)
@@ -909,7 +909,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                 attributedDescription.uiKit.foregroundColor = .label
                 descriptionTextView.attributedText = NSAttributedString(attributedDescription)
             } else {
-                descriptionTextView.text = claim?.value?.description
+                descriptionTextView.text = singleClaim.value?.description
             }
         }
     }

--- a/Odysee/Utils/Lbryio.swift
+++ b/Odysee/Utils/Lbryio.swift
@@ -343,11 +343,16 @@ enum Lbryio {
         return user
     }
 
-    static func areCommentsEnabled(channelId: String, channelName: String, completion: @escaping (Bool) -> Void) {
+    static func areCommentsEnabled(
+        claimId: String,
+        channelId: String?,
+        channelName: String?,
+        completion: @escaping (Bool) -> Void
+    ) {
         Lbry.commentApiCall(
             method: CommentsMethods.list,
             params: .init(
-                claimId: channelId,
+                claimId: claimId,
                 channelId: channelId,
                 channelName: channelName,
                 page: 1,


### PR DESCRIPTION
Fix: #549
Fix: file_vc skips checking on content published by Anonymous

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Changes

* **Refactor**
  * Improved comment-checking logic to use the content's primary ID and accept optional channel identifiers, making availability checks more flexible across scenarios.

* **Bug Fixes**
  * Fixed cases where comment availability couldn't be determined for certain content by ensuring checks run using the passed-in claim details and content metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->