### PR TITLE
"Last Playback Position" Fixes

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             self,
             selector: #selector(playerDidFinishPlaying),
             name: .AVPlayerItemDidPlayToEndTime,
-            object: nil
+            object: lazyPlayer?.currentItem
         )
     }
 

--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -395,7 +395,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // This isn't 100% reliable, just will save position most times
     func savePlaybackPosition() {
         if let time = lazyPlayer?.currentTime().seconds,
-           let claimUrl = currentFileViewController?.claim?.permanentUrl
+           let vc = currentFileViewController,
+           let claimUrl = vc.isPlaylist ? vc.currentPlaylistClaim()?.permanentUrl : vc.claim?.permanentUrl
         {
             currentFileViewController?.logFileView(url: claimUrl, timeToStart: 0, position: Int(time))
         }

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -1205,6 +1205,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             return
         }
 
+        let claim = isPlaylist ? currentPlaylistClaim() : claim
         guard let claimId = claim?.claimId, let txid = claim?.txid, let nout = claim?.nout else {
             showError(message: "couldn't get claim info")
             return

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -170,7 +170,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     var isOtherContent = false
     var membersOnly = false
     var avpcInitialised = false
-    var lastPosition: UInt = 0
+    var lastPosition: CMTime?
 
     var loadingChannels = false
     var postingChat = false
@@ -187,6 +187,9 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     let availableRates = ["0.25x", "0.5x", "0.75x", "1x", "1.25x", "1.5x", "1.75x", "2x"]
 
     var needRestoreHeader = false
+
+    /// If last position is within 15 seconds of end, play from start
+    static let minimumLastPositionBeforeEnd: Double = 15
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -1109,13 +1112,6 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
 
         avpc.player = currentPlayer
 
-        if lastPosition > 0 {
-            avpc.player?.seek(
-                to: CMTime(seconds: Double(lastPosition), preferredTimescale: 1),
-                toleranceBefore: .zero, toleranceAfter: .zero
-            )
-        }
-
         playerStartedObserver = currentPlayer?.observe(\.rate, options: .new) { [self] _, _ in
             playerStartedObserver = nil
 
@@ -1144,8 +1140,17 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         }
 
         Task {
-            _ = try? await asset.load(.duration)
+            let duration = try? await asset.load(.duration)
             mediaLoadingIndicator.isHidden = true
+
+            if let lastPosition, let duration,
+               (duration - lastPosition).seconds > Self.minimumLastPositionBeforeEnd
+            {
+                await avpc.player?.seek(
+                    to: lastPosition,
+                    toleranceBefore: .zero, toleranceAfter: .zero
+                )
+            }
         }
 
         AppDelegate.shared.lazyPlayer?.pause()
@@ -1593,7 +1598,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                                claimIds: [claimId]
                            ))[claimId]
                         {
-                            self.lastPosition = lastPosition
+                            self.lastPosition = CMTime(seconds: Double(lastPosition), preferredTimescale: 1)
                         }
                     } catch {
                         Helper.showError(error: error)

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -1593,6 +1593,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
 
                 // Wait for last positions to succeed/fail, so it's available when playback begins
                 Task {
+                    self.lastPosition = nil
                     do {
                         if let claimId = singleClaim.claimId,
                            let lastPosition = try await AccountMethods.fileLastPositions.call(params: .init(


### PR DESCRIPTION
[vc(file): play from start if last position is near end](https://github.com/OdyseeTeam/odysee-ios/commit/186f407a6feaa4e07040f51973d381b1dc16950c) 
Fix: Video played to end will be skipped (especially in playlist)

[project(file last position): use playlist item if playlist](https://github.com/OdyseeTeam/odysee-ios/commit/cab7a2ee0780d4ae522611f111df6af3d762b2d1) 
Fix: Sending file/view event for playlist instead of current item

[ui(player): observe "play to end" for current item only](https://github.com/OdyseeTeam/odysee-ios/commit/b68cdc6cd507ea46f287fb1719a67efec0da96b4) 
Fix: playerDidFinishPlaying called multiple times, skips playlist items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scoped playback-end notifications to the active item to avoid receiving end events for unrelated media.
  * Improved playback-position tracking using precise time values to better preserve where playback stopped.
  * Resume is deferred until media duration is available and will not resume if close to the end.
  * Saving/restoring now selects the correct item when viewing or resuming playlist content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->