### PR TITLE
project(player): add setting to loop playback

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -36,6 +36,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var currentTimeControlStatus: AVPlayer.TimeControlStatus?
     var remoteCommands = [CommandCenterCommands: Any]()
 
+    var didShowLoopNotification = false
+
     // One-time only lazily activate the Audio Session when playing a file.
     // This prevents the app from taking over the audio stream on launch.
     lazy var lazyPlayer: AVPlayer? = {
@@ -80,11 +82,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     @objc func playerDidFinishPlaying(note: NSNotification) {
-        removeRemoteTransportControls()
-        (mainViewController as? MainViewController)?.miniPlayerPlayPauseButton.isUserInteractionEnabled = false
+        if UserDefaults.standard.bool(forKey: "LoopVideos") {
+            if !didShowLoopNotification {
+                Helper.showMessage(message: "Looping this video — go to Settings to disable")
+                didShowLoopNotification = true
+            }
 
-        if let currentFileViewController {
-            currentFileViewController.playNextPlaylistItem()
+            // TODO: Consider using AVQueuePlayer/AVPlayerLooper
+            lazyPlayer?.seek(to: .zero)
+            lazyPlayer?.play()
+        } else {
+            removeRemoteTransportControls()
+            (mainViewController as? MainViewController)?.miniPlayerPlayPauseButton.isUserInteractionEnabled = false
+
+            if let currentFileViewController {
+                currentFileViewController.playNextPlaylistItem()
+            }
         }
     }
 

--- a/Odysee/Settings.bundle/Root.plist
+++ b/Odysee/Settings.bundle/Root.plist
@@ -26,6 +26,16 @@
 				<integer>1</integer>
 			</array>
 		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Loop Videos</string>
+			<key>Key</key>
+			<string>LoopVideos</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Fix: #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Loop Videos" toggle in Settings. When enabled, videos automatically restart from the beginning upon reaching the end and display a one-time helper message.
* **Behavior**
  * When disabled, playback preserves the prior end-of-playback behavior: controls are reset and playback advances to the next item when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->