### PR TITLE
vc(main): restore mini player on load

### DIFF
--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -101,6 +101,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
         loadBlockedOutpoints()
         loadFilteredOutpoints()
         loadLocaleAndCustomBlockedRules()
+        updateMiniPlayer()
 
         if Lbryio.isSignedIn() {
             // check if the user is pending_delete
@@ -595,6 +596,8 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
             playerLayer.videoGravity = .resizeAspectFill
             _ = mediaViewLayer.sublayers?.popLast()
             mediaViewLayer.addSublayer(playerLayer)
+
+            toggleMiniPlayer(hidden: false)
         }
     }
 


### PR DESCRIPTION
Fix: mini player hidden/not updated when signing in/out
Fix: #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured mini-player displays correctly when the app initializes with available content and playback capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->