### PR TITLE
utils: SharePublished wrapper

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		534CCCA52F3C5EAC00457BBF /* YouTubeSyncScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534CCCA42F3C5EAC00457BBF /* YouTubeSyncScreen.swift */; };
 		534CCCA92F3C74CC00457BBF /* YouTubeSyncViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534CCCA82F3C74CC00457BBF /* YouTubeSyncViewModel.swift */; };
 		53593F31287E5D75007FD08E /* CommentsAPIResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53593F30287E5D75007FD08E /* CommentsAPIResult.swift */; };
+		535BD0412FBD4A9100E4FE19 /* SharePublished.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BD0402FBD4A9100E4FE19 /* SharePublished.swift */; };
 		536E27C32EB1B55700A02197 /* LbryUriTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536E27C22EB1B55700A02197 /* LbryUriTest.swift */; };
 		5377EA832F7B666E00C8E03E /* LibraryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377EA822F7B666E00C8E03E /* LibraryScreen.swift */; };
 		5377EA852F7B6C3300C8E03E /* PublishesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377EA842F7B6C3300C8E03E /* PublishesScreen.swift */; };
@@ -168,6 +169,7 @@
 		534CCCA42F3C5EAC00457BBF /* YouTubeSyncScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeSyncScreen.swift; sourceTree = "<group>"; };
 		534CCCA82F3C74CC00457BBF /* YouTubeSyncViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeSyncViewModel.swift; sourceTree = "<group>"; };
 		53593F30287E5D75007FD08E /* CommentsAPIResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsAPIResult.swift; sourceTree = "<group>"; };
+		535BD0402FBD4A9100E4FE19 /* SharePublished.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePublished.swift; sourceTree = "<group>"; };
 		536E27C22EB1B55700A02197 /* LbryUriTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LbryUriTest.swift; sourceTree = "<group>"; };
 		5377EA822F7B666E00C8E03E /* LibraryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryScreen.swift; sourceTree = "<group>"; };
 		5377EA842F7B6C3300C8E03E /* PublishesScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishesScreen.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 				5385091F28E13D28009A7AAB /* MembershipPerk.swift */,
 				53D59FFB2EF3AE530081D800 /* Methods.swift */,
 				53D59FFD2EF3B3150081D800 /* QueryItemsCoder.swift */,
+				535BD0402FBD4A9100E4FE19 /* SharePublished.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -921,6 +924,7 @@
 				641AFAE925B606E000218BD9 /* UAButton.swift in Sources */,
 				644F76AE25592F8400813451 /* FileViewController.swift in Sources */,
 				CC97807926549867009F580E /* Log.swift in Sources */,
+				535BD0412FBD4A9100E4FE19 /* SharePublished.swift in Sources */,
 				53D59FFC2EF3AE530081D800 /* Methods.swift in Sources */,
 				534CCCA52F3C5EAC00457BBF /* YouTubeSyncScreen.swift in Sources */,
 				64FBE79D25502A290082AF2E /* AppDelegate.swift in Sources */,

--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -172,7 +172,7 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
         }
 
         Task {
-            for await _ in await Wallet.shared.sBlocked {
+            for await _ in await Wallet.shared.$blocked {
                 if let claimId = channelClaim?.claimId {
                     blockUnblockLabel.text = String.localized(
                         await Wallet.shared.isBlocked(claimId: claimId) ?

--- a/Odysee/Controllers/Content/CommentsViewController.swift
+++ b/Odysee/Controllers/Content/CommentsViewController.swift
@@ -300,7 +300,7 @@ class CommentsViewController: UIViewController, UITableViewDelegate, UITableView
                 updateCommentAsChannel(index)
             }
 
-            for await blocked in await Wallet.shared.sBlocked {
+            for await blocked in await Wallet.shared.$blocked {
                 guard let blocked = blocked?.map(\.claimId) else {
                     continue
                 }

--- a/Odysee/Controllers/Content/FollowingViewController.swift
+++ b/Odysee/Controllers/Content/FollowingViewController.swift
@@ -129,7 +129,7 @@ class FollowingViewController: UIViewController, UICollectionViewDataSource, UIC
         Task {
             await update(await Wallet.shared.following)
 
-            for await newFollowing in await Wallet.shared.sFollowing {
+            for await newFollowing in await Wallet.shared.$following {
                 await update(newFollowing)
             }
         }

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -115,7 +115,7 @@ class HomeViewController: UIViewController,
         }
 
         Task {
-            for await blocked in await Wallet.shared.sBlocked {
+            for await blocked in await Wallet.shared.$blocked {
                 guard let blocked = blocked?.map(\.claimId) else {
                     continue
                 }

--- a/Odysee/Utils/SharePublished.swift
+++ b/Odysee/Utils/SharePublished.swift
@@ -1,0 +1,39 @@
+//
+//  SharePublished.swift
+//  Odysee
+//
+//  Created by Keith Toh on 20/05/2026.
+//
+
+import AsyncExtensions
+import Foundation
+
+/// Like `Published` but can be accessed from multiple client loops
+@propertyWrapper
+public struct SharePublished<T> where T: Equatable {
+    private var value: T
+
+    private var share: AsyncShareSequence<AsyncBufferedChannel<T>>
+    private let queue = AsyncBufferedChannel<T>()
+
+    public var wrappedValue: T {
+        get {
+            value
+        }
+        set {
+            if value != newValue {
+                queue.send(newValue)
+                value = newValue
+            }
+        }
+    }
+
+    public var projectedValue: AsyncShareSequence<AsyncBufferedChannel<T>> {
+        share
+    }
+
+    public init(wrappedValue: T) {
+        value = wrappedValue
+        share = queue.share()
+    }
+}

--- a/Odysee/ViewModels/Wallet.swift
+++ b/Odysee/ViewModels/Wallet.swift
@@ -23,27 +23,9 @@ actor Wallet {
 
     typealias Following = [LbryUri: NotificationsDisabled]
 
-    private(set) var following: Following? {
-        didSet {
-            if following != oldValue {
-                followingQueue.send(following)
-            }
-        }
-    }
+    @SharePublished private(set) var following: Following?
 
-    private(set) var sFollowing: AsyncShareSequence<AsyncBufferedChannel<Following?>>
-    private let followingQueue = AsyncBufferedChannel<Following?>()
-
-    private(set) var blocked: [LbryUri]? {
-        didSet {
-            if blocked != oldValue {
-                blockedQueue.send(blocked)
-            }
-        }
-    }
-
-    private(set) var sBlocked: AsyncShareSequence<AsyncBufferedChannel<[LbryUri]?>>
-    private let blockedQueue = AsyncBufferedChannel<[LbryUri]?>()
+    @SharePublished private(set) var blocked: [LbryUri]?
 
     private(set) var defaultChannelId: String?
 
@@ -56,9 +38,6 @@ actor Wallet {
     private let pushQueue = AsyncBufferedChannel<Void>()
 
     private init() {
-        sFollowing = followingQueue.share()
-        sBlocked = blockedQueue.share()
-
         Task {
             await startSync()
             await monitorPushQueue()


### PR DESCRIPTION
Like @Published but can be accessed from multiple client loops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal wallet state management for blocked claims and following lists, improving code maintainability and adopting cleaner async patterns throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->