### PR TITLE
util(QueryItemsCoder): convert camelCase keys to snake_case

### DIFF
--- a/Odysee/Models/AccountAPIParams.swift
+++ b/Odysee/Models/AccountAPIParams.swift
@@ -23,11 +23,6 @@ struct FileLastPositionsParams: Encodable, AccountMethodParams {
 struct UserNewParams: Encodable, AccountMethodParams {
     let language = "en"
     var appId: String
-
-    enum CodingKeys: String, CodingKey {
-        case language
-        case appId = "app_id"
-    }
 }
 
 struct UserExistsParams: Encodable, AccountMethodParams {
@@ -42,11 +37,6 @@ struct UserSignInUpParams: Encodable, AccountMethodParams {
 struct UserEmailResendTokenParams: Encodable, AccountMethodParams {
     var email: String
     let onlyIfExpired = true
-
-    enum CodingKeys: String, CodingKey {
-        case email
-        case onlyIfExpired = "only_if_expired"
-    }
 }
 
 struct SyncGetParams: Encodable, AccountMethodParams {
@@ -57,50 +47,25 @@ struct SyncSetParams: Encodable, AccountMethodParams {
     var oldHash: String
     var newHash: String
     var data: String
-
-    enum CodingKeys: String, CodingKey {
-        case oldHash = "old_hash"
-        case newHash = "new_hash"
-        case data
-    }
 }
 
 struct SubscriptionNewParams: Encodable, AccountMethodParams {
     var claimId: String
     var channelName: String
     var notificationsDisabled: Bool
-
-    enum CodingKeys: String, CodingKey {
-        case claimId = "claim_id"
-        case channelName = "channel_name"
-        case notificationsDisabled = "notifications_disabled"
-    }
 }
 
 struct SubscriptionDeleteParams: Encodable, AccountMethodParams {
     var claimId: String
-
-    enum CodingKeys: String, CodingKey {
-        case claimId = "claim_id"
-    }
 }
 
 struct ViewHistoryParams: Encodable, AccountMethodParams {
     var page: Int?
     var pageSize: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case page
-        case pageSize = "page_size"
-    }
 }
 
 struct ViewHistoryDeleteParams: Encodable, AccountMethodParams {
     var claimId: String
-
-    enum CodingKeys: String, CodingKey {
-        case claimId = "claim_id"
-    }
 }
 
 struct YtNewParams: Encodable, AccountMethodParams {
@@ -109,22 +74,9 @@ struct YtNewParams: Encodable, AccountMethodParams {
     var channelLanguage: String
     var desiredLbryChannelName: String
     let returnUrl = YouTubeSyncScreen.Setup.returnUrl
-
-    enum CodingKeys: String, CodingKey {
-        case type
-        case immediateSync = "immediate_sync"
-        case channelLanguage = "channel_language"
-        case desiredLbryChannelName = "desired_lbry_channel_name"
-        case returnUrl = "return_url"
-    }
 }
 
 struct YtTransferParams: Encodable, AccountMethodParams {
     var address: String
     var publicKey: String
-
-    enum CodingKeys: String, CodingKey {
-        case address
-        case publicKey = "public_key"
-    }
 }

--- a/Odysee/Utils/Methods.swift
+++ b/Odysee/Utils/Methods.swift
@@ -180,11 +180,6 @@ extension Method where ParamType: AccountMethodParams {
         }
 
         let respCode = httpResponse.statusCode
-        Crashlytics.crashlytics().setCustomValue(
-            String(data: data, encoding: .utf8),
-            forKey: "Lbryio.call_data"
-        )
-        Crashlytics.crashlytics().setCustomValue(respCode, forKey: "Lbryio.call_respCode")
 
         let response = try JSONDecoder().decode(LbryioAPIResponse<ResultType>.self, from: data)
 

--- a/Odysee/Utils/QueryItemsCoder.swift
+++ b/Odysee/Utils/QueryItemsCoder.swift
@@ -9,6 +9,7 @@
 
 import Foundation
 
+/// Converts all keys to snake case
 public class QueryItemsEncoder {
     public init() {}
 
@@ -23,8 +24,64 @@ private struct QueryItemsEncoding: Encoder {
     fileprivate final class QueryItems {
         private(set) var queryItems: [URLQueryItem] = []
 
+        /// <https://github.com/swiftlang/swift-foundation/blob/5da00f0dc72b182f50dd292421b0436b55ddc869/Sources/FoundationEssentials/JSON/JSONEncoder.swift#L175-L222>
+        fileprivate static func convertToSnakeCase(_ stringKey: String) -> String {
+            guard !stringKey.isEmpty else { return stringKey }
+
+            var words: [Range<String.Index>] = []
+            // The general idea of this algorithm is to split words on transition from lower to upper case, then on transition of >1 upper case characters to lowercase
+            //
+            // myProperty -> my_property
+            // myURLProperty -> my_url_property
+            //
+            // We assume, per Swift naming conventions, that the first character of the key is lowercase.
+            var wordStart = stringKey.startIndex
+            var searchRange = stringKey.index(after: wordStart) ..< stringKey.endIndex
+
+            // Find next uppercase character
+            while let upperCaseRange = stringKey[searchRange].rangeOfCharacter(
+                from: .uppercaseLetters,
+                options: []
+            ) {
+                let untilUpperCase = wordStart ..< upperCaseRange.lowerBound
+                words.append(untilUpperCase)
+
+                // Find next lowercase character
+                searchRange = upperCaseRange.lowerBound ..< searchRange.upperBound
+                guard let lowerCaseRange = stringKey[searchRange].rangeOfCharacter(
+                    from: .lowercaseLetters,
+                    options: []
+                ) else {
+                    // There are no more lower case letters. Just end here.
+                    wordStart = searchRange.lowerBound
+                    break
+                }
+
+                // Is the next lowercase letter more than 1 after the uppercase? If so, we encountered a group of uppercase letters that we should treat as its own word
+                let nextCharacterAfterCapital = stringKey.index(after: upperCaseRange.lowerBound)
+                if lowerCaseRange.lowerBound == nextCharacterAfterCapital {
+                    // The next character after capital is a lower case character and therefore not a word boundary.
+                    // Continue searching for the next upper case for the boundary.
+                    wordStart = upperCaseRange.lowerBound
+                } else {
+                    // There was a range of >1 capital letters. Turn those into a word, stopping at the capital before the lower case character.
+                    let beforeLowerIndex = stringKey.index(before: lowerCaseRange.lowerBound)
+                    words.append(upperCaseRange.lowerBound ..< beforeLowerIndex)
+
+                    // Next word starts at the capital before the lowercase we just found
+                    wordStart = beforeLowerIndex
+                }
+                searchRange = lowerCaseRange.upperBound ..< searchRange.upperBound
+            }
+            words.append(wordStart ..< searchRange.upperBound)
+            let result = words.map { range in
+                return stringKey[range].lowercased()
+            }.joined(separator: "_")
+            return result
+        }
+
         func encode(key codingKey: CodingKey, value: String?) {
-            let name = codingKey.stringValue
+            let name = Self.convertToSnakeCase(codingKey.stringValue)
             queryItems.append(URLQueryItem(name: name, value: value))
         }
     }
@@ -146,6 +203,7 @@ private struct QueryItemsKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerPr
     }
 }
 
+/// Preserves keys as-is (no conversion from snake case)
 public class QueryItemsDecoder {
     public init() {}
 

--- a/OdyseeTests/QueryItemsCoderTest.swift
+++ b/OdyseeTests/QueryItemsCoderTest.swift
@@ -10,6 +10,10 @@ import Odysee
 import Testing
 
 struct QueryItemsCoderTests {
+    struct CamelCase: Codable {
+        var thisThing: String
+    }
+
     struct Params: Codable, Equatable {
         var email: String
         var password: String
@@ -82,6 +86,13 @@ struct QueryItemsCoderTests {
         }
     }
 
+    @Test func decode_camelCase() async throws {
+        var components = URLComponents()
+        components.percentEncodedQuery = "thisThing=hellorld"
+        let result = try QueryItemsDecoder().decode(CamelCase.self, from: components.queryItems!)
+        #expect(result.thisThing == "hellorld")
+    }
+
     /// fatalError expected
     /*
      struct NestedParams: Codable {
@@ -125,5 +136,12 @@ struct QueryItemsCoderTests {
         components = URLComponents()
         components.queryItems = items
         #expect(components.percentEncodedQuery == "maybe=true")
+    }
+
+    @Test func encode_camelCase() async throws {
+        let items = try QueryItemsEncoder().encode(CamelCase(thisThing: "hellorld"))
+        var components = URLComponents()
+        components.queryItems = items
+        #expect(components.percentEncodedQuery == "this_thing=hellorld")
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified request parameter encoding by removing explicit per-field key mappings and relying on default encoding behavior; query parameters are now encoded using automatic snake_case conversion.

* **Chores**
  * Removed crash analytics logging for API response details.

* **Tests**
  * Added tests to verify snake_case query parameter encoding and decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->