### PR TITLE
vc(library): only load screens when signed in

### DIFF
--- a/Odysee/Controllers/Library/LibraryViewController.swift
+++ b/Odysee/Controllers/Library/LibraryViewController.swift
@@ -25,13 +25,9 @@ class LibraryViewController: UIViewController {
             // show the sign in view
             let vc = storyboard?.instantiateViewController(identifier: "ua_vc") as! UserAccountViewController
             AppDelegate.shared.mainNavigationController?.pushViewController(vc, animated: true)
+        } else {
+            setupLibraryView()
         }
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        setupLibraryView()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -49,6 +45,10 @@ class LibraryViewController: UIViewController {
     }
 
     func setupLibraryView() {
+        guard library.parent == nil else {
+            return
+        }
+
         addChild(library)
         view.addSubview(library.view)
         library.didMove(toParent: self)


### PR DESCRIPTION
Fix: "authentication required" error appears when navigating to Libary screen when signed out, even though sign-in screen appears. This is due to the screens within Library trying to make authenticated calls.

Fix: #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signed-out users are now redirected to the sign-in screen when opening the Library.
  * Library content is only initialized for signed-in users, improving access control and navigation behavior.
* **Performance / Reliability**
  * Prevents duplicate Library UI setup when the Library screen is revisited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->