### PR TITLE
fix: sign out race condition

### DIFF
--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -104,10 +104,14 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
         updateMiniPlayer()
 
         if Lbryio.isSignedIn() {
+            // FIXME: This only runs after reopening app, not immediately when signing in
             // check if the user is pending_delete
             if let pendingDeletion = Lbryio.currentUser?.pendingDeletion, pendingDeletion {
-                stopAllTimers()
-                resetUserAndViews()
+                Task {
+                    await stopAllTimers()
+                    await resetUserAndViews()
+                    rerunInit()
+                }
                 return
             }
 
@@ -170,13 +174,13 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
         AppDelegate.shared.mainNavigationController?.pushViewController(vc, animated: true)
     }
 
-    func stopAllTimers() {
+    func stopAllTimers() async {
         walletBalanceTimer.invalidate()
         balanceTimerScheduled = false
-        Task { await Wallet.shared.stopSync() }
+        await Wallet.shared.stopSync()
     }
 
-    func resetUserAndViews() {
+    func resetUserAndViews() async {
         Lbryio.cachedNotifications = []
         Lbry.walletBalance = WalletBalance()
 
@@ -186,16 +190,24 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate, MFMa
 
         // remove the auth token so that a new one will be generated upon the next init
         Lbryio.Defaults.reset()
-        Task { await AuthToken.reset() }
+        await AuthToken.reset()
 
         // clear the wallet address if it exists
         UserDefaults.standard.removeObject(forKey: Helper.keyReceiveAddress)
 
         AppDelegate.shared.mainNavigationController?.popToRootViewController(animated: false)
-        if let initvc = presentingViewController as? InitViewController {
-            initvc.dismiss(animated: true, completion: {
-                Task { await initvc.runInit() }
-            })
+    }
+
+    func rerunInit() {
+        let initVc = storyboard?.instantiateViewController(identifier: "init_vc") as! InitViewController
+        if let window = view.window {
+            window.rootViewController = initVc
+            UIView.transition(
+                with: window,
+                duration: 0.2,
+                options: .transitionCrossDissolve,
+                animations: nil
+            )
         }
     }
 

--- a/Odysee/Controllers/User/UserAccountMenuViewController.swift
+++ b/Odysee/Controllers/User/UserAccountMenuViewController.swift
@@ -109,19 +109,11 @@ class UserAccountMenuViewController: UIViewController, UIGestureRecognizerDelega
     }
 
     @IBAction func signOutTapped(_ sender: Any) {
-        presentingViewController?.dismiss(animated: false, completion: nil)
-        AppDelegate.shared.mainController?.stopAllTimers()
-        AppDelegate.shared.mainController?.resetUserAndViews()
-
-        let initVc = storyboard?.instantiateViewController(identifier: "init_vc") as! InitViewController
-        if let window = view.window {
-            window.rootViewController = initVc
-            UIView.transition(
-                with: window,
-                duration: 0.2,
-                options: .transitionCrossDissolve,
-                animations: nil
-            )
+        Task {
+            presentingViewController?.dismiss(animated: false, completion: nil)
+            await AppDelegate.shared.mainController?.stopAllTimers()
+            await AppDelegate.shared.mainController?.resetUserAndViews()
+            AppDelegate.shared.mainController?.rerunInit()
         }
     }
 


### PR DESCRIPTION
Run sign out steps async/await so runInit is only called after the AuthToken is reset (`user/signout` is called).

Fix: After signing out the app still appears signed in but has "authentication required" for all actions, until next launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out and account deletion cleanup to complete reliably before returning to initialization.
  * Ensured timers, wallet synchronization, authentication state, and user data are fully reset during sign-out.
  * Improved the transition back to the initialization screen with a smoother visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->